### PR TITLE
chore: bump version to 2.5.0-next.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,5 @@
         "package": "ncc build --source-map --license licenses.txt",
         "test": "jest"
     },
-    "version": "2.2.1"
+    "version": "2.5.0-next.1"
 }


### PR DESCRIPTION
### TL;DR

Bumped version number to 2.5.0-next.1

### What changed?

Updated the version number in `package.json` from 2.2.1 to 2.5.0-next.1.

### How to test?

1. Check that the version number in `package.json` is correctly updated to 2.5.0-next.1.
2. Ensure that any dependent systems or scripts referencing the package version are still functioning correctly with the new version number.

### Why make this change?

This version bump likely indicates the preparation for a new pre-release version of the package. The change from 2.2.1 to 2.5.0-next.1 suggests significant updates or new features are being introduced in this upcoming version.