### PR TITLE
test: update jest config to typescript

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: MIT
 
-module.exports = {
+import type { Config } from 'jest'
+
+const config: Config = {
     clearMocks: true,
     moduleFileExtensions: ['js', 'ts'],
     testTimeout: 30000,
@@ -21,3 +23,5 @@ module.exports = {
     ],
     verbose: true
 }
+
+export default config

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "prettier": "3.3.3",
         "prettier-plugin-multiline-arrays": "3.0.6",
         "ts-jest": "29.2.5",
+        "ts-node": "^10.9.2",
         "typescript": "5.6.2",
         "typescript-eslint": "8.8.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,13 +37,13 @@ importers:
                 version: 9.11.1
             eslint-plugin-jest:
                 specifier: 28.8.3
-                version: 28.8.3(@typescript-eslint/eslint-plugin@8.8.0(@typescript-eslint/parser@8.8.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(jest@29.7.0(@types/node@20.16.10))(typescript@5.6.2)
+                version: 28.8.3(@typescript-eslint/eslint-plugin@8.8.0(@typescript-eslint/parser@8.8.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(jest@29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2)))(typescript@5.6.2)
             globals:
                 specifier: 15.10.0
                 version: 15.10.0
             jest:
                 specifier: 29.7.0
-                version: 29.7.0(@types/node@20.16.10)
+                version: 29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))
             js-yaml:
                 specifier: 4.1.0
                 version: 4.1.0
@@ -55,7 +55,10 @@ importers:
                 version: 3.0.6(prettier@3.3.3)
             ts-jest:
                 specifier: 29.2.5
-                version: 29.2.5(@babel/core@7.25.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.8))(jest@29.7.0(@types/node@20.16.10))(typescript@5.6.2)
+                version: 29.2.5(@babel/core@7.25.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.8))(jest@29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2)))(typescript@5.6.2)
+            ts-node:
+                specifier: ^10.9.2
+                version: 10.9.2(@types/node@20.16.10)(typescript@5.6.2)
             typescript:
                 specifier: 5.6.2
                 version: 5.6.2
@@ -390,6 +393,13 @@ packages:
                 integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
             }
 
+    '@cspotcode/source-map-support@0.8.1':
+        resolution:
+            {
+                integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+            }
+        engines: { node: '>=12' }
+
     '@eslint-community/eslint-utils@4.4.0':
         resolution:
             {
@@ -624,6 +634,12 @@ packages:
                 integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
             }
 
+    '@jridgewell/trace-mapping@0.3.9':
+        resolution:
+            {
+                integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+            }
+
     '@nodelib/fs.scandir@2.1.5':
         resolution:
             {
@@ -671,6 +687,30 @@ packages:
         engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
         peerDependencies:
             eslint: '>=8.40.0'
+
+    '@tsconfig/node10@1.0.11':
+        resolution:
+            {
+                integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
+            }
+
+    '@tsconfig/node12@1.0.11':
+        resolution:
+            {
+                integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+            }
+
+    '@tsconfig/node14@1.0.3':
+        resolution:
+            {
+                integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+            }
+
+    '@tsconfig/node16@1.0.4':
+        resolution:
+            {
+                integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+            }
 
     '@types/babel__core@7.20.5':
         resolution:
@@ -912,6 +952,13 @@ packages:
         peerDependencies:
             acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+    acorn-walk@8.3.4:
+        resolution:
+            {
+                integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+            }
+        engines: { node: '>=0.4.0' }
+
     acorn@8.12.1:
         resolution:
             {
@@ -967,6 +1014,12 @@ packages:
                 integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
             }
         engines: { node: '>= 8' }
+
+    arg@4.1.3:
+        resolution:
+            {
+                integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+            }
 
     argparse@1.0.10:
         resolution:
@@ -1216,6 +1269,12 @@ packages:
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
         hasBin: true
 
+    create-require@1.1.1:
+        resolution:
+            {
+                integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+            }
+
     cross-spawn@7.0.3:
         resolution:
             {
@@ -1272,6 +1331,13 @@ packages:
                 integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
             }
         engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
+
+    diff@4.0.2:
+        resolution:
+            {
+                integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+            }
+        engines: { node: '>=0.3.1' }
 
     ejs@3.1.10:
         resolution:
@@ -2743,6 +2809,23 @@ packages:
             esbuild:
                 optional: true
 
+    ts-node@10.9.2:
+        resolution:
+            {
+                integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+            }
+        hasBin: true
+        peerDependencies:
+            '@swc/core': '>=1.2.50'
+            '@swc/wasm': '>=1.2.50'
+            '@types/node': '*'
+            typescript: '>=2.7'
+        peerDependenciesMeta:
+            '@swc/core':
+                optional: true
+            '@swc/wasm':
+                optional: true
+
     tunnel@0.0.6:
         resolution:
             {
@@ -2826,6 +2909,12 @@ packages:
                 integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
             }
 
+    v8-compile-cache-lib@3.0.1:
+        resolution:
+            {
+                integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+            }
+
     v8-to-istanbul@9.3.0:
         resolution:
             {
@@ -2900,6 +2989,13 @@ packages:
                 integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
             }
         engines: { node: '>=12' }
+
+    yn@3.1.1:
+        resolution:
+            {
+                integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+            }
+        engines: { node: '>=6' }
 
     yocto-queue@0.1.0:
         resolution:
@@ -3149,6 +3245,10 @@ snapshots:
 
     '@bcoe/v8-coverage@0.2.3': {}
 
+    '@cspotcode/source-map-support@0.8.1':
+        dependencies:
+            '@jridgewell/trace-mapping': 0.3.9
+
     '@eslint-community/eslint-utils@4.4.0(eslint@9.11.1)':
         dependencies:
             eslint: 9.11.1
@@ -3213,7 +3313,7 @@ snapshots:
             jest-util: 29.7.0
             slash: 3.0.0
 
-    '@jest/core@29.7.0':
+    '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))':
         dependencies:
             '@jest/console': 29.7.0
             '@jest/reporters': 29.7.0
@@ -3227,7 +3327,7 @@ snapshots:
             exit: 0.1.2
             graceful-fs: 4.2.11
             jest-changed-files: 29.7.0
-            jest-config: 29.7.0(@types/node@20.16.10)
+            jest-config: 29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))
             jest-haste-map: 29.7.0
             jest-message-util: 29.7.0
             jest-regex-util: 29.6.3
@@ -3383,6 +3483,11 @@ snapshots:
             '@jridgewell/resolve-uri': 3.1.2
             '@jridgewell/sourcemap-codec': 1.5.0
 
+    '@jridgewell/trace-mapping@0.3.9':
+        dependencies:
+            '@jridgewell/resolve-uri': 3.1.2
+            '@jridgewell/sourcemap-codec': 1.5.0
+
     '@nodelib/fs.scandir@2.1.5':
         dependencies:
             '@nodelib/fs.stat': 2.0.5
@@ -3416,6 +3521,14 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
             - typescript
+
+    '@tsconfig/node10@1.0.11': {}
+
+    '@tsconfig/node12@1.0.11': {}
+
+    '@tsconfig/node14@1.0.3': {}
+
+    '@tsconfig/node16@1.0.4': {}
 
     '@types/babel__core@7.20.5':
         dependencies:
@@ -3607,6 +3720,10 @@ snapshots:
         dependencies:
             acorn: 8.12.1
 
+    acorn-walk@8.3.4:
+        dependencies:
+            acorn: 8.12.1
+
     acorn@8.12.1: {}
 
     ajv@6.12.6:
@@ -3636,6 +3753,8 @@ snapshots:
         dependencies:
             normalize-path: 3.0.0
             picomatch: 2.3.1
+
+    arg@4.1.3: {}
 
     argparse@1.0.10:
         dependencies:
@@ -3787,13 +3906,13 @@ snapshots:
 
     convert-source-map@2.0.0: {}
 
-    create-jest@29.7.0(@types/node@20.16.10):
+    create-jest@29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2)):
         dependencies:
             '@jest/types': 29.6.3
             chalk: 4.1.2
             exit: 0.1.2
             graceful-fs: 4.2.11
-            jest-config: 29.7.0(@types/node@20.16.10)
+            jest-config: 29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))
             jest-util: 29.7.0
             prompts: 2.4.2
         transitivePeerDependencies:
@@ -3801,6 +3920,8 @@ snapshots:
             - babel-plugin-macros
             - supports-color
             - ts-node
+
+    create-require@1.1.1: {}
 
     cross-spawn@7.0.3:
         dependencies:
@@ -3821,6 +3942,8 @@ snapshots:
     detect-newline@3.1.0: {}
 
     diff-sequences@29.6.3: {}
+
+    diff@4.0.2: {}
 
     ejs@3.1.10:
         dependencies:
@@ -3844,13 +3967,13 @@ snapshots:
 
     escape-string-regexp@4.0.0: {}
 
-    eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.8.0(@typescript-eslint/parser@8.8.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(jest@29.7.0(@types/node@20.16.10))(typescript@5.6.2):
+    eslint-plugin-jest@28.8.3(@typescript-eslint/eslint-plugin@8.8.0(@typescript-eslint/parser@8.8.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(jest@29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2)))(typescript@5.6.2):
         dependencies:
             '@typescript-eslint/utils': 8.8.1(eslint@9.11.1)(typescript@5.6.2)
             eslint: 9.11.1
         optionalDependencies:
             '@typescript-eslint/eslint-plugin': 8.8.0(@typescript-eslint/parser@8.8.0(eslint@9.11.1)(typescript@5.6.2))(eslint@9.11.1)(typescript@5.6.2)
-            jest: 29.7.0(@types/node@20.16.10)
+            jest: 29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))
         transitivePeerDependencies:
             - supports-color
             - typescript
@@ -4180,16 +4303,16 @@ snapshots:
             - babel-plugin-macros
             - supports-color
 
-    jest-cli@29.7.0(@types/node@20.16.10):
+    jest-cli@29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2)):
         dependencies:
-            '@jest/core': 29.7.0
+            '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))
             '@jest/test-result': 29.7.0
             '@jest/types': 29.6.3
             chalk: 4.1.2
-            create-jest: 29.7.0(@types/node@20.16.10)
+            create-jest: 29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))
             exit: 0.1.2
             import-local: 3.2.0
-            jest-config: 29.7.0(@types/node@20.16.10)
+            jest-config: 29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))
             jest-util: 29.7.0
             jest-validate: 29.7.0
             yargs: 17.7.2
@@ -4199,7 +4322,7 @@ snapshots:
             - supports-color
             - ts-node
 
-    jest-config@29.7.0(@types/node@20.16.10):
+    jest-config@29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2)):
         dependencies:
             '@babel/core': 7.25.8
             '@jest/test-sequencer': 29.7.0
@@ -4225,6 +4348,7 @@ snapshots:
             strip-json-comments: 3.1.1
         optionalDependencies:
             '@types/node': 20.16.10
+            ts-node: 10.9.2(@types/node@20.16.10)(typescript@5.6.2)
         transitivePeerDependencies:
             - babel-plugin-macros
             - supports-color
@@ -4444,12 +4568,12 @@ snapshots:
             merge-stream: 2.0.0
             supports-color: 8.1.1
 
-    jest@29.7.0(@types/node@20.16.10):
+    jest@29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2)):
         dependencies:
-            '@jest/core': 29.7.0
+            '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))
             '@jest/types': 29.6.3
             import-local: 3.2.0
-            jest-cli: 29.7.0(@types/node@20.16.10)
+            jest-cli: 29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))
         transitivePeerDependencies:
             - '@types/node'
             - babel-plugin-macros
@@ -4770,12 +4894,12 @@ snapshots:
         dependencies:
             typescript: 5.6.2
 
-    ts-jest@29.2.5(@babel/core@7.25.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.8))(jest@29.7.0(@types/node@20.16.10))(typescript@5.6.2):
+    ts-jest@29.2.5(@babel/core@7.25.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.8))(jest@29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2)))(typescript@5.6.2):
         dependencies:
             bs-logger: 0.2.6
             ejs: 3.1.10
             fast-json-stable-stringify: 2.1.0
-            jest: 29.7.0(@types/node@20.16.10)
+            jest: 29.7.0(@types/node@20.16.10)(ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2))
             jest-util: 29.7.0
             json5: 2.2.3
             lodash.memoize: 4.1.2
@@ -4788,6 +4912,24 @@ snapshots:
             '@jest/transform': 29.7.0
             '@jest/types': 29.6.3
             babel-jest: 29.7.0(@babel/core@7.25.8)
+
+    ts-node@10.9.2(@types/node@20.16.10)(typescript@5.6.2):
+        dependencies:
+            '@cspotcode/source-map-support': 0.8.1
+            '@tsconfig/node10': 1.0.11
+            '@tsconfig/node12': 1.0.11
+            '@tsconfig/node14': 1.0.3
+            '@tsconfig/node16': 1.0.4
+            '@types/node': 20.16.10
+            acorn: 8.12.1
+            acorn-walk: 8.3.4
+            arg: 4.1.3
+            create-require: 1.1.1
+            diff: 4.0.2
+            make-error: 1.3.6
+            typescript: 5.6.2
+            v8-compile-cache-lib: 3.0.1
+            yn: 3.1.1
 
     tunnel@0.0.6: {}
 
@@ -4829,6 +4971,8 @@ snapshots:
     uri-js@4.4.1:
         dependencies:
             punycode: 2.3.1
+
+    v8-compile-cache-lib@3.0.1: {}
 
     v8-to-istanbul@9.3.0:
         dependencies:
@@ -4874,5 +5018,7 @@ snapshots:
             string-width: 4.2.3
             y18n: 5.0.8
             yargs-parser: 21.1.1
+
+    yn@3.1.1: {}
 
     yocto-queue@0.1.0: {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "exclude": [
         "node_modules",
         "**/*.test.ts",
-        "megalinter-reports/**/*.js"
+        "megalinter-reports/**/*.js",
+        "jest.config.ts"
     ]
 }


### PR DESCRIPTION
### TL;DR

Converted Jest configuration to TypeScript and updated related files.

### What changed?

- Renamed `jest.config.js` to `jest.config.ts`
- Updated Jest configuration to use TypeScript syntax
- Added `collectCoverageFrom` option to Jest config
- Added `ts-node` as a dev dependency
- Updated `tsconfig.json` to exclude `jest.config.ts`

### How to test?

1. Run `pnpm install` to install the new `ts-node` dependency
2. Execute Jest tests to ensure they still pass with the new configuration
3. Check that code coverage is now collected from all TypeScript files in the `src` directory

### Why make this change?

Converting the Jest configuration to TypeScript provides better type checking and consistency with the rest of the project's TypeScript setup. Adding the `collectCoverageFrom` option ensures more accurate code coverage reporting for the project's source files.