### PR TITLE
ci: remove hardcoded PNPM version

### DIFF
--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -37,7 +37,6 @@ jobs:
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
         with:
           run_install: false
-          version: ${{vars.PNPM_VERSION}}
 
       - name: Set Node.js 20.x
         uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,6 @@ jobs:
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
         with:
           run_install: false
-          version: 9.11.0
 
       - name: Set Node.js 20.x
         uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,6 @@ jobs:
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
         with:
           run_install: false
-          version: 9.11.0
 
       - name: Set Node.js 20.x
         uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4


### PR DESCRIPTION
### TL;DR

Removed explicit PNPM version specifications from GitHub Actions workflows.

### What changed?

- Removed the `version` parameter from the `pnpm/action-setup` step in the following workflows:
  - `check-dist.yaml`
  - `release.yaml`
  - `test.yaml`

### How to test?

1. Run the affected GitHub Actions workflows to ensure they complete successfully.
2. Verify that PNPM is correctly set up and used in the workflow runs without specifying a version.

### Why make this change?

By removing the explicit PNPM version, we allow the workflows to use the latest stable version of PNPM automatically. This reduces maintenance overhead and ensures we're always using an up-to-date version of PNPM without manual intervention.