### PR TITLE
refactor: validateInputs now uses the types

### DIFF
--- a/__tests__/validateInputs.test.ts
+++ b/__tests__/validateInputs.test.ts
@@ -4,75 +4,84 @@
 
 import { validateInputs } from '../src/utils/validateInputs'
 import { MAXIMUM_ALLOWED, MINIMUM_ALLOWED } from '../src/constants'
+import { err, ok } from 'true-myth/result'
+import { InputValidationSuccess } from '../src/types/validationSuccessTypes'
+import {
+    BelowMinimumAllowedError,
+    ExceedsMaximumAllowedTimeError,
+    MinimumNotLessThanMaximumError,
+    NotAnIntegerError,
+    NotANumberError
+} from '../src/types/validationErrorTypes'
+
+test('succeesds with valid input', () => {
+    const result = validateInputs(1, 10)
+    expect(result).toEqual(ok(new InputValidationSuccess()))
+})
 
 test('fails with invalid input', () => {
     const minimum = parseInt('foo', 10)
     const maximum = parseInt('bar', 10)
-    expect(() => validateInputs(minimum, maximum)).toThrow(
-        'minimum and maximum must be numbers'
-    )
+    const result = validateInputs(minimum, maximum)
+    expect(result).toEqual(err(new NotANumberError()))
 })
 
 test('fails with a non-integer minimum', () => {
     const minimum = 2.5
     const maximum = 10
-    expect(() => validateInputs(minimum, maximum)).toThrow(
-        'minimum and maximum values must be positive integers'
-    )
+    const result = validateInputs(minimum, maximum)
+    expect(result).toEqual(err(new NotAnIntegerError()))
 })
 
 test('fails with a non-integer maximum', () => {
     const minimum = 2
     const maximum = 10.8
-    expect(() => validateInputs(minimum, maximum)).toThrow(
-        'minimum and maximum values must be positive integers'
-    )
+    const result = validateInputs(minimum, maximum)
+    expect(result).toEqual(err(new NotAnIntegerError()))
 })
 
 test('fails if minimum is higher than maximum', () => {
     const minimum = 10
     const maximum = 5
-    expect(() => validateInputs(minimum, maximum)).toThrow(
-        'minimum must be strictly less than maximum'
-    )
+    const result = validateInputs(minimum, maximum)
+    expect(result).toEqual(err(new MinimumNotLessThanMaximumError()))
 })
 
 test('fails if maximum is lower than minimum', () => {
     const minimum = 10
     const maximum = 5
-    expect(() => validateInputs(minimum, maximum)).toThrow(
-        'minimum must be strictly less than maximum'
-    )
+    const result = validateInputs(minimum, maximum)
+    expect(result).toEqual(err(new MinimumNotLessThanMaximumError()))
 })
 
 test('fails if minimum is higher than limit', () => {
     const minimum = 121
     const maximum = 60
-    expect(() => validateInputs(minimum, maximum)).toThrow(
-        `minimum and maximum must be less than or equal to ${MAXIMUM_ALLOWED}`
+    const result = validateInputs(minimum, maximum)
+    expect(result).toEqual(
+        err(new ExceedsMaximumAllowedTimeError(MAXIMUM_ALLOWED))
     )
 })
 
 test('fails if maximum is higher than limit', () => {
     const minimum = 100
     const maximum = 121
-    expect(() => validateInputs(minimum, maximum)).toThrow(
-        `minimum and maximum must be less than or equal to ${MAXIMUM_ALLOWED}`
+    const result = validateInputs(minimum, maximum)
+    expect(result).toEqual(
+        err(new ExceedsMaximumAllowedTimeError(MAXIMUM_ALLOWED))
     )
 })
 
 test('fails if minimum is lower than limit', () => {
     const minimum = -2
     const maximum = 10
-    expect(() => validateInputs(minimum, maximum)).toThrow(
-        `minimum and maximum values must be greater than ${MINIMUM_ALLOWED}`
-    )
+    const result = validateInputs(minimum, maximum)
+    expect(result).toEqual(err(new BelowMinimumAllowedError(MINIMUM_ALLOWED)))
 })
 
 test('fails if maximum is lower than limit', () => {
     const minimum = 2
     const maximum = -10
-    expect(() => validateInputs(minimum, maximum)).toThrow(
-        `minimum and maximum values must be greater than ${MINIMUM_ALLOWED}`
-    )
+    const result = validateInputs(minimum, maximum)
+    expect(result).toEqual(err(new BelowMinimumAllowedError(MINIMUM_ALLOWED)))
 })

--- a/src/utils/validateInputs.ts
+++ b/src/utils/validateInputs.ts
@@ -2,7 +2,17 @@
 //
 // SPDX-License-Identifier: MIT
 
+import Result, { err, ok } from 'true-myth/result'
 import { MINIMUM_ALLOWED, MAXIMUM_ALLOWED } from '../constants'
+import {
+    NotANumberError,
+    NotAnIntegerError,
+    ExceedsMaximumAllowedTimeError,
+    MinimumNotLessThanMaximumError,
+    BelowMinimumAllowedError,
+    InputValidationError
+} from '../types/validationErrorTypes'
+import { InputValidationSuccess } from '../types/validationSuccessTypes'
 
 /**
  * Validates the minimum and maximum wait time inputs.
@@ -14,28 +24,29 @@ import { MINIMUM_ALLOWED, MAXIMUM_ALLOWED } from '../constants'
  * @throws {Error} If the minimum or maximum values are outside the allowed range.
  * @throws {Error} If the minimum value is greater than the maximum value.
  */
-export function validateInputs(minimum: number, maximum: number): void {
+export function validateInputs(
+    minimum: number,
+    maximum: number
+): Result<InputValidationSuccess, InputValidationError> {
     if (isNaN(minimum) || isNaN(maximum)) {
-        throw new Error('minimum and maximum must be numbers')
+        return err(new NotANumberError())
     }
 
     if (!Number.isInteger(minimum) || !Number.isInteger(maximum)) {
-        throw new Error('minimum and maximum values must be positive integers')
+        return err(new NotAnIntegerError())
     }
 
     if (minimum > MAXIMUM_ALLOWED || maximum > MAXIMUM_ALLOWED) {
-        throw new Error(
-            `minimum and maximum must be less than or equal to ${MAXIMUM_ALLOWED}`
-        )
+        return err(new ExceedsMaximumAllowedTimeError(MAXIMUM_ALLOWED))
     }
 
     if (minimum < MINIMUM_ALLOWED || maximum < MINIMUM_ALLOWED) {
-        throw new Error(
-            `minimum and maximum values must be greater than ${MINIMUM_ALLOWED}`
-        )
+        return err(new BelowMinimumAllowedError(MINIMUM_ALLOWED))
     }
 
     if (minimum >= maximum) {
-        throw new Error('minimum must be strictly less than maximum')
+        return err(new MinimumNotLessThanMaximumError())
     }
+
+    return ok(new InputValidationSuccess())
 }


### PR DESCRIPTION
### TL;DR

Refactored input validation to use Result types instead of throwing errors.

### What changed?

- Modified `validateInputs` function to return a `Result` type from the `true-myth` library instead of throwing errors
- Created specific error classes for different validation failures
- Updated tests to check for returned `Result` objects instead of thrown exceptions
- Added a success test case to verify valid inputs return an `ok` result

### How to test?

Run the test suite to verify all validation scenarios work correctly:
```
pnpm test
```

### Why make this change?

This change improves error handling by using a more functional approach with Result types. Instead of throwing exceptions that need to be caught, the function now returns a structured Result object that can be more easily handled by calling code. This makes the validation logic more composable and easier to integrate with other parts of the application.