### PR TITLE
build: remove references to jest

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-import jestPlugin from 'eslint-plugin-jest'
 import globals from 'globals'
 import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
@@ -19,7 +18,6 @@ export default tseslint.config(
     eslint.configs.recommended,
     {
         plugins: {
-            jest: jestPlugin,
             '@typescript-eslint': tseslint.plugin,
             '@stylistic': stylistic
         },
@@ -95,10 +93,5 @@ export default tseslint.config(
     {
         files: ['**/*.js', '**/*.cjs', '**/*.mjs'],
         ...tseslint.configs.disableTypeChecked
-    },
-    {
-        // enable jest rules on test files
-        files: ['__test__/**'],
-        ...jestPlugin.configs['flat/recommended']
     }
 )


### PR DESCRIPTION
### TL;DR

Removed Jest ESLint plugin configuration from the project.

### What changed?

- Removed the import for `eslint-plugin-jest`
- Removed Jest from the plugins configuration
- Removed the Jest-specific configuration for test files

### How to test?

1. Run ESLint on the codebase to ensure there are no linting errors
2. Verify that test files still pass linting without the Jest-specific rules

### Why make this change?

This change simplifies the ESLint configuration by removing the Jest-specific linting rules. This could be because the project is no longer using Jest for testing, or because the Jest-specific rules were causing issues or were deemed unnecessary for the project's testing approach.