### PR TITLE
tests: update test infrastructure

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: MIT
 
-import globals from 'globals'
 import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import stylistic from '@stylistic/eslint-plugin'
+import vitest from '@vitest/eslint-plugin'
 
 export default tseslint.config(
     {
@@ -93,5 +93,13 @@ export default tseslint.config(
     {
         files: ['**/*.js', '**/*.cjs', '**/*.mjs'],
         ...tseslint.configs.disableTypeChecked
+    },
+    {
+        files: ['__tests__/*.test.ts'],
+        plugins: { vitest },
+        rules: {
+            ...vitest.configs.all.rules,
+            'vitest/max-nested-describe': ['error', { max: 3 }]
+        }
     }
 )

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@types/eslint": "9.6.1",
         "@vercel/ncc": "0.38.3",
         "@vitest/coverage-v8": "^3.1.1",
+        "@vitest/eslint-plugin": "^1.1.42",
         "@vitest/ui": "^3.1.1",
         "eslint": "9.24.0",
         "fast-check": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       "@vitest/coverage-v8":
         specifier: ^3.1.1
         version: 3.1.1(vitest@3.1.1)
+      "@vitest/eslint-plugin":
+        specifier: ^1.1.42
+        version: 1.1.42(@typescript-eslint/utils@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.24.0(jiti@1.21.7))(typescript@5.7.3)(vitest@3.1.1)
       "@vitest/ui":
         specifier: ^3.1.1
         version: 3.1.1(vitest@3.1.1)
@@ -920,6 +923,20 @@ packages:
       vitest: 3.1.1
     peerDependenciesMeta:
       "@vitest/browser":
+        optional: true
+
+  "@vitest/eslint-plugin@1.1.42":
+    resolution:
+      {
+        integrity: sha512-dTGNbh/angh+hoqp5L5A8YO/29mOXDXmDQ/1fzt/jiYzLvU6FvrMqJpGqMqh5g+Fz6MDoZi0AlxefnFUg93Q5A==
+      }
+    peerDependencies:
+      "@typescript-eslint/utils": ">= 8.24.0"
+      eslint: ">= 8.57.0"
+      typescript: ">= 5.0.0"
+      vitest: "*"
+    peerDependenciesMeta:
+      typescript:
         optional: true
 
   "@vitest/expect@3.1.1":
@@ -2742,6 +2759,14 @@ snapshots:
       vitest: 3.1.1(@types/node@22.13.5)(@vitest/ui@3.1.1)(jiti@1.21.7)
     transitivePeerDependencies:
       - supports-color
+
+  "@vitest/eslint-plugin@1.1.42(@typescript-eslint/utils@8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.24.0(jiti@1.21.7))(typescript@5.7.3)(vitest@3.1.1)":
+    dependencies:
+      "@typescript-eslint/utils": 8.29.1(eslint@9.24.0(jiti@1.21.7))(typescript@5.7.3)
+      eslint: 9.24.0(jiti@1.21.7)
+      vitest: 3.1.1(@types/node@22.13.5)(@vitest/ui@3.1.1)(jiti@1.21.7)
+    optionalDependencies:
+      typescript: 5.7.3
 
   "@vitest/expect@3.1.1":
     dependencies:


### PR DESCRIPTION
### TL;DR

Added Vitest ESLint plugin to enforce test code quality standards.

### What changed?

- Added `@vitest/eslint-plugin` as a dev dependency
- Configured ESLint to use Vitest plugin rules for test files
- Set a specific rule to limit nested describe blocks to a maximum of 3 levels

### How to test?

1. Run ESLint on test files to verify the new rules are applied:
   ```
   pnpm run lint
   ```
2. Try creating a test with more than 3 nested describe blocks to confirm the rule is enforced

### Why make this change?

This change improves test code quality by enforcing Vitest-specific best practices through ESLint. The max-nested-describe rule in particular helps maintain readable and maintainable test files by preventing excessive nesting that can make tests difficult to understand.