### PR TITLE
tests: ensure the property based test for negatives does not generate zero

### DIFF
--- a/__tests__/validateInputs.test.ts
+++ b/__tests__/validateInputs.test.ts
@@ -88,8 +88,8 @@ describe('validateInputs (property-based)', () => {
 
         fc.assert(
             fc.property(
-                fc.integer({ max: 0 }),
-                fc.integer({ max: 0 }),
+                fc.integer({ max: -1 }),
+                fc.integer({ max: -1 }),
                 (min, max) => {
                     const result = validateInputs(min, max)
 


### PR DESCRIPTION
### TL;DR

Fixed test case for negative input validation by using strictly negative integers.

### What changed?

Modified the property-based test for `validateInputs` to use strictly negative integers (`max: -1`) instead of zero or negative integers (`max: 0`). This ensures the test properly validates the behavior for negative inputs only.

### How to test?

Run the test suite to verify that the property-based tests for `validateInputs` pass correctly:
```
pnpm test -- validateInputs.test.ts
```

### Why make this change?

The previous test was using integers that could be 0, which might not properly test the validation logic if it treats 0 differently than negative numbers. By restricting the test to strictly negative integers, we ensure the validation logic is tested with the correct input range.