### PR TITLE
build: ensure vitest types are available to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
         "outDir": "./lib",
         "rootDir": "./src",
         "strict": true,
-        "target": "es6"
+        "target": "es6",
+        "types": [
+            "vitest"
+        ]
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
### TL;DR

Added Vitest types to TypeScript configuration.

### What changed?

Updated `tsconfig.json` to include Vitest types in the TypeScript compiler options. This ensures that Vitest-specific globals and types are recognized by the TypeScript compiler without requiring explicit imports.

### How to test?

1. Run TypeScript type checking to ensure there are no errors
2. Verify that Vitest test files compile correctly without type errors
3. Confirm that Vitest globals (like `describe`, `it`, `expect`) are recognized without explicit imports

### Why make this change?

This change improves the developer experience by providing proper TypeScript type checking and autocompletion for Vitest test files. It eliminates the need for explicit imports of Vitest types in test files and ensures that the TypeScript compiler recognizes Vitest-specific globals.