### PR TITLE
fix: remove inferrable types from the constants

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 // Set the minimum time limit to 0 seconds
-export const MINIMUM_ALLOWED: number = 0
+export const MINIMUM_ALLOWED = 0
 
 // Set the maximum time limit to 2 minutes (120 seconds)
-export const MAXIMUM_ALLOWED: number = 120
+export const MAXIMUM_ALLOWED = 120


### PR DESCRIPTION
### TL;DR

Removed explicit type annotations from constant declarations in `constants.ts`.

### What changed?

Removed the explicit `: number` type annotations from `MINIMUM_ALLOWED` and `MAXIMUM_ALLOWED` constants, relying on TypeScript's type inference instead.

### How to test?

1. Verify that the application builds successfully
2. Ensure that time limit functionality works as expected
3. Confirm that TypeScript correctly infers the number type for these constants

### Why make this change?

This change improves code consistency by leveraging TypeScript's type inference capabilities. Since the constants are initialized with numeric values (0 and 120), TypeScript can automatically infer their types without explicit annotations, making the code cleaner and more maintainable.