### PR TITLE
build: remove the vitest types from main tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,7 @@
         "outDir": "./lib",
         "rootDir": "./src",
         "strict": true,
-        "target": "es6",
-        "types": [
-            "vitest"
-        ]
+        "target": "es6"
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
### TL;DR

Removed "vitest" from the types array in tsconfig.json.

### What changed?

Removed the "types" configuration from tsconfig.json that previously included "vitest". This simplifies the TypeScript configuration by no longer explicitly including vitest types.

### How to test?

1. Verify that TypeScript compilation still works correctly by running the build process
2. Ensure that tests still run properly with vitest
3. Check that there are no new TypeScript errors related to missing vitest types

### Why make this change?

This change likely removes an unnecessary explicit inclusion of vitest types. TypeScript can automatically detect and use types from installed packages without explicitly listing them in the tsconfig.json file. This makes the configuration cleaner and more maintainable.