### PR TITLE
tests: add tests for the constants

### DIFF
--- a/__tests__/constants.test.ts
+++ b/__tests__/constants.test.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
+//
+// SPDX-License-Identifier: MIT
+
+import { describe, it, expect } from 'vitest'
+import { MAXIMUM_ALLOWED, MINIMUM_ALLOWED } from '../src/constants'
+
+describe('ensure constants are correctly set', () => {
+    it('has correct maximum value', () => {
+        expect.hasAssertions()
+
+        expect(MAXIMUM_ALLOWED).toBe(120)
+    })
+
+    it('has correct minimum value', () => {
+        expect.hasAssertions()
+
+        expect(MINIMUM_ALLOWED).toBe(0)
+    })
+})


### PR DESCRIPTION
### TL;DR

Added unit tests for constants to ensure they maintain their expected values.

### What changed?

Created a new test file `__tests__/constants.test.ts` that verifies the values of `MAXIMUM_ALLOWED` and `MINIMUM_ALLOWED` constants. The tests ensure that `MAXIMUM_ALLOWED` is set to 120 and `MINIMUM_ALLOWED` is set to 0.

### How to test?

Run the test suite to verify that the constants are correctly set:

```bash
pnpm test
```

### Why make this change?

These tests provide a safeguard against accidental changes to critical constant values that might affect application behavior. By explicitly testing these values, we ensure that any future modifications to these constants will require updating the tests, making such changes more intentional and visible.