### PR TITLE
tests: add tests for invalid inputs for `wait`

### DIFF
--- a/__tests__/wait.test.ts
+++ b/__tests__/wait.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi } from 'vitest'
 import { wait } from '../src/wait'
+import { InputValidationError } from '../src/utils/errors'
 
 const timingBuffer = 1000 // milliseconds to account for timer inaccuracy and async delays
 
@@ -57,5 +58,71 @@ describe('wait (mocked setTimeout)', () => {
             }
         })
         vi.useRealTimers()
+    })
+})
+
+describe('wait errors out on invalid inputs', () => {
+    it('errors out if maximum is less than minimum', async () => {
+        expect.hasAssertions()
+
+        const result = await wait(2, 0)
+
+        result.match({
+            Ok: () => {
+                throw new Error('Expected Err but got Ok')
+            },
+            Err: error => {
+                expect(error).toBeInstanceOf(InputValidationError)
+                expect(error.message).toMatch(/minimum.*greater.*maximum/i)
+            }
+        })
+    })
+
+    it('errors out if both minimum and maximum are zero', async () => {
+        expect.hasAssertions()
+
+        const result = await wait(0, 0)
+
+        result.match({
+            Ok: () => {
+                throw new Error('Expected Err but got Ok')
+            },
+            Err: error => {
+                expect(error).toBeInstanceOf(InputValidationError)
+                expect(error.message).toMatch(/cannot be zero/i)
+            }
+        })
+    })
+
+    it('errors out if both minimum and maximum are not integers', async () => {
+        expect.hasAssertions()
+
+        const result = await wait(2.5, 4.5)
+
+        result.match({
+            Ok: () => {
+                throw new Error('Expected Err but got Ok')
+            },
+            Err: error => {
+                expect(error).toBeInstanceOf(InputValidationError)
+                expect(error.message).toMatch(/integers/i)
+            }
+        })
+    })
+
+    it('errors out if both minimum and maximum are not numbers', async () => {
+        expect.hasAssertions()
+
+        const result = await wait('a', 'd')
+
+        result.match({
+            Ok: () => {
+                throw new Error('Expected Err but got Ok')
+            },
+            Err: error => {
+                expect(error).toBeInstanceOf(InputValidationError)
+                expect(error.message).toMatch(/numbers/i)
+            }
+        })
     })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,18 @@ export default defineConfig({
         environment: 'node',
         coverage: {
             provider: 'v8', // Or 'c8'
-            reporter: ['text', 'html', 'json']
+            reporter: ['text', 'html', 'json'],
+            exclude: [
+                'lib',
+                'node_modules',
+                'node_modules/**',
+                'vitest.config.ts',
+                '**/*.test.ts',
+                '**/__tests__/**',
+                'src/main.ts',
+                'dist/',
+                'eslint.config.mjs'
+            ]
         },
         testTimeout: 30000
     }


### PR DESCRIPTION
### TL;DR

Added input validation tests for the `wait` function and improved test coverage configuration.

### What changed?

- Added new test cases to validate error handling in the `wait` function for various invalid inputs:
  - When maximum is less than minimum
  - When both minimum and maximum are zero
  - When inputs are not integers
  - When inputs are not numbers
- Updated the Vitest configuration to exclude irrelevant files from coverage reports, including:
  - Build output directories
  - Test files
  - Configuration files
  - Main entry point

### How to test?

1. Run the test suite with `pnpm test` to verify all tests pass
2. Check that the new input validation tests correctly identify invalid inputs
3. Generate a coverage report to confirm the excluded files are not counted

### Why make this change?

This change improves test coverage for the `wait` function by ensuring it properly validates inputs and handles error cases. The updated coverage configuration provides more accurate metrics by excluding files that shouldn't be part of the coverage calculation, resulting in a clearer picture of actual code coverage.