### PR TITLE
tests(ci): update the github action to ensure coverage is uploaded

### DIFF
--- a/.github/workflows/sonar-cloud.yaml
+++ b/.github/workflows/sonar-cloud.yaml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm run test:coverage
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@b42848bfdabac7fefc656c08af7a7864240124a3 # master
+        uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 # v5.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,8 +9,9 @@ export default defineConfig({
         globals: true, // So you don't need to import `describe`, `it`, etc.
         environment: 'node',
         coverage: {
+            enabled: true,
             provider: 'v8', // Or 'c8'
-            reporter: ['text', 'html', 'json'],
+            reporter: ['text', 'html', 'json', 'json-summary', 'lcov'],
             exclude: [
                 'lib',
                 'node_modules',


### PR DESCRIPTION
### TL;DR

Updated SonarCloud GitHub action and enhanced test coverage configuration.

### What changed?

- Updated SonarCloud GitHub action from using the `sonarcloud-github-action` to `sonarqube-scan-action` version 5.1.0
- Enhanced test coverage configuration in `vitest.config.ts`:
  - Explicitly enabled coverage
  - Added `json-summary` and `lcov` reporters to the coverage output formats

### How to test?

1. Run the GitHub workflow that uses SonarCloud to verify it works with the new action
2. Run tests with coverage using `pnpm run test:coverage` and verify that all specified report formats are generated

### Why make this change?

The update to the SonarQube scan action provides access to the latest features and fixes from the official SonarSource tooling. The additional coverage reporters (especially lcov) improve compatibility with various code quality tools and dashboards, making it easier to track and visualize test coverage metrics.