### PR TITLE
fix: mark private vars as readonly

### DIFF
--- a/src/RandomWaitAction.ts
+++ b/src/RandomWaitAction.ts
@@ -8,8 +8,8 @@ import { validateInputs } from './utils/validateInputs'
 import { InputValidationError } from './utils/errors'
 
 export class RandomWaitAction {
-    private minimum: number
-    private maximum: number
+    private readonly minimum: number
+    private readonly maximum: number
 
     constructor(minimum: number, maximum: number) {
         this.minimum = minimum


### PR DESCRIPTION
### TL;DR

Added `readonly` modifiers to the `minimum` and `maximum` properties in the `RandomWaitAction` class.

### What changed?

Modified the `minimum` and `maximum` properties in the `RandomWaitAction` class to be `readonly`, preventing them from being reassigned after initialization.

### How to test?

1. Verify that the `RandomWaitAction` class still functions correctly
2. Try to reassign the `minimum` or `maximum` properties after initialization and confirm that TypeScript compilation fails

### Why make this change?

This change improves type safety by ensuring that the wait time boundaries cannot be accidentally modified after the `RandomWaitAction` instance is created. Since these properties are only meant to be set during initialization, making them `readonly` better communicates their intended usage and prevents potential bugs.