### PR TITLE
ci: update the names of Node.js installation actions

### DIFF
--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           run_install: false
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 22.x
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 22.x

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           run_install: false
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 22.x
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 22.x

--- a/.github/workflows/sonar-cloud.yaml
+++ b/.github/workflows/sonar-cloud.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           run_install: false
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 22.x
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 22.x

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           run_install: false
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 22.x
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 22.x
@@ -77,7 +77,7 @@ jobs:
         with:
           run_install: false
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 22.x
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 22.x


### PR DESCRIPTION
### TL;DR

Updated Node.js version from 20.x to 22.x in all GitHub workflow files.

### What changed?

Modified all GitHub workflow files to use Node.js 22.x instead of 20.x:
- Updated `check-dist.yaml`
- Updated `release.yaml`
- Updated `sonar-cloud.yaml`
- Updated `test.yaml` (in two places)

The step names in each workflow were changed from "Set Node.js 20.x" to "Set Node.js 22.x", while the actual node-version parameter was updated to match.

### How to test?

1. Run the GitHub workflows to verify they execute successfully with Node.js 22.x
2. Verify that all builds, tests, and other CI processes complete without errors
3. Check that the distribution files are correctly generated with the new Node.js version

### Why make this change?

Upgrading to Node.js 22.x allows the project to leverage the latest features, performance improvements, and security updates available in the newer Node.js version. This keeps the development environment current with modern standards and ensures compatibility with the latest dependencies.