### PR TITLE
ci: fix the http accesses

### DIFF
--- a/.github/workflows/sonar-cloud.yaml
+++ b/.github/workflows/sonar-cloud.yaml
@@ -32,6 +32,7 @@ jobs:
             registry.npmjs.org:443
             scanner.sonarcloud.io:443
             sonarcloud.io:443
+            api.sonarcloud.io:443
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### TL;DR

Added `api.sonarcloud.io:443` to the allowed hosts in the SonarCloud GitHub workflow.

### What changed?

Added `api.sonarcloud.io:443` to the list of allowed hosts in the network access configuration for the SonarCloud GitHub workflow.

### How to test?

Run the SonarCloud GitHub workflow and verify that it can successfully connect to the SonarCloud API.

### Why make this change?

The SonarCloud workflow needs to communicate with the SonarCloud API to report analysis results. Without this host in the allowed list, the workflow may fail due to network access restrictions, especially in environments with strict network policies.