### PR TITLE
build: add a rollup config

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2022 - 2025 Ali Sajid Imami
+//
+// SPDX-License-Identifier: MIT
+
+// See: https://rollupjs.org/introduction/
+
+import commonjs from '@rollup/plugin-commonjs'
+import nodeResolve from '@rollup/plugin-node-resolve'
+import typescript from '@rollup/plugin-typescript'
+
+const config = {
+    input: 'src/index.ts',
+    output: {
+        esModule: true,
+        file: 'dist/index.js',
+        format: 'es',
+        sourcemap: true
+    },
+    plugins: [typescript(), nodeResolve({ preferBuiltins: true }), commonjs()]
+}
+
+export default config


### PR DESCRIPTION
### TL;DR

Added Rollup configuration for bundling the project.

### What changed?

Added a new `rollup.config.ts` file that configures Rollup to:
- Use TypeScript, CommonJS, and Node Resolve plugins
- Bundle from `src/index.ts` entry point
- Output to `dist/index.js` in ES module format with source maps

### How to test?

1. Install dependencies if needed: `npm install @rollup/plugin-commonjs @rollup/plugin-node-resolve @rollup/plugin-typescript`
2. Run the build process: `npx rollup -c`
3. Verify that `dist/index.js` is created with proper ES module format

### Why make this change?

This configuration enables proper bundling of the TypeScript codebase into a distributable ES module format, making the package more compatible with modern JavaScript environments while preserving source maps for debugging.