### PR TITLE
style: add semicolon at the end of lines

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -20,7 +20,7 @@
         "prettier-plugin-multiline-arrays"
     ],
     "printWidth": 80,
-    "semi": false,
+    "semi": true,
     "singleQuote": true,
     "tabWidth": 4,
     "trailingComma": "none",

--- a/__tests__/RandomWaitAction.test.ts
+++ b/__tests__/RandomWaitAction.test.ts
@@ -2,163 +2,163 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { describe, expect, vi, it } from 'vitest'
-import { RandomWaitAction } from '../src/RandomWaitAction'
-import { InputValidationError } from '../src/utils/errors'
+import { describe, expect, vi, it } from 'vitest';
+import { RandomWaitAction } from '../src/RandomWaitAction';
+import { InputValidationError } from '../src/utils/errors';
 
-vi.useFakeTimers()
+vi.useFakeTimers();
 
 describe('test RandomWaitAction class', () => {
     it('waits for a time between 1 and 3 seconds when inputs are valid', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        vi.restoreAllMocks()
-        vi.clearAllTimers()
+        vi.restoreAllMocks();
+        vi.clearAllTimers();
 
-        const action = new RandomWaitAction(1, 3)
+        const action = new RandomWaitAction(1, 3);
 
-        const promise = action.execute()
+        const promise = action.execute();
 
         // Fast-forward timers so the promise can resolve
-        vi.runAllTimers()
-        const result = await promise
+        vi.runAllTimers();
+        const result = await promise;
 
         result.match({
             Ok: seconds => {
-                expect(seconds).toBeGreaterThanOrEqual(1)
-                expect(seconds).toBeLessThanOrEqual(3)
+                expect(seconds).toBeGreaterThanOrEqual(1);
+                expect(seconds).toBeLessThanOrEqual(3);
             },
             Err: () => {
-                throw new Error('Expected Ok but got Err')
+                throw new Error('Expected Ok but got Err');
             }
-        })
-    })
+        });
+    });
 
     it('resolves immediately when min and max are equal', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const action = new RandomWaitAction(2, 2)
+        const action = new RandomWaitAction(2, 2);
 
-        const promise = action.execute()
-        vi.runAllTimers()
-        const result = await promise
+        const promise = action.execute();
+        vi.runAllTimers();
+        const result = await promise;
 
         result.match({
             Ok: seconds => {
-                expect(seconds).toBe(2)
+                expect(seconds).toBe(2);
             },
             Err: () => {
-                throw new Error('Expected Ok but got Err')
+                throw new Error('Expected Ok but got Err');
             }
-        })
-    })
+        });
+    });
 
     it('returns error if minimum is greater than maximum', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const action = new RandomWaitAction(10, 5)
+        const action = new RandomWaitAction(10, 5);
 
-        const result = await action.execute()
+        const result = await action.execute();
 
-        expect(result.isErr).toBe(true)
+        expect(result.isErr).toBe(true);
 
         result.match({
             Ok: () => {
-                throw new Error('Expected Err but got Ok')
+                throw new Error('Expected Err but got Ok');
             },
             Err: error => {
-                expect(error).toBeInstanceOf(InputValidationError)
-                expect(error.message).toMatch(/minimum.*greater.*maximum/i)
+                expect(error).toBeInstanceOf(InputValidationError);
+                expect(error.message).toMatch(/minimum.*greater.*maximum/i);
             }
-        })
-    })
+        });
+    });
 
     it('returns error if minimum is negative', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const action = new RandomWaitAction(-2, 5)
+        const action = new RandomWaitAction(-2, 5);
 
-        const result = await action.execute()
+        const result = await action.execute();
 
-        expect(result.isErr).toBe(true)
+        expect(result.isErr).toBe(true);
 
         result.match({
             Ok: () => {
-                throw new Error('Expected Err but got Ok')
+                throw new Error('Expected Err but got Ok');
             },
             Err: error => {
-                expect(error.message).toMatch(/positive integer/i)
+                expect(error.message).toMatch(/positive integer/i);
             }
-        })
-    })
+        });
+    });
 
     it('returns error if maximum is negative', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const action = new RandomWaitAction(2, -5)
+        const action = new RandomWaitAction(2, -5);
 
-        const result = await action.execute()
+        const result = await action.execute();
 
-        expect(result.isErr).toBe(true)
+        expect(result.isErr).toBe(true);
 
         result.match({
             Ok: () => {
-                throw new Error('Expected Err but got Ok')
+                throw new Error('Expected Err but got Ok');
             },
             Err: error => {
-                expect(error.message).toMatch(/positive integer/i)
+                expect(error.message).toMatch(/positive integer/i);
             }
-        })
-    })
+        });
+    });
 
     it('returns error if both are zero', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const action = new RandomWaitAction(0, 0)
+        const action = new RandomWaitAction(0, 0);
 
-        const result = await action.execute()
+        const result = await action.execute();
 
-        expect(result.isErr).toBe(true)
+        expect(result.isErr).toBe(true);
 
         result.match({
             Ok: () => {
-                throw new Error('Expected Err but got Ok')
+                throw new Error('Expected Err but got Ok');
             },
             Err: error => {
-                expect(error.message).toMatch(/cannot be zero/i)
+                expect(error.message).toMatch(/cannot be zero/i);
             }
-        })
-    })
+        });
+    });
 
     it('returns error if maximum is zero and minimum is positive', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const action = new RandomWaitAction(1, 0)
+        const action = new RandomWaitAction(1, 0);
 
-        const result = await action.execute()
+        const result = await action.execute();
 
-        expect(result.isErr).toBe(true)
+        expect(result.isErr).toBe(true);
 
         result.match({
             Ok: () => {
-                throw new Error('Expected Err but got Ok')
+                throw new Error('Expected Err but got Ok');
             },
             Err: error => {
-                expect(error.message).toMatch(/minimum.*greater.*maximum/i)
+                expect(error.message).toMatch(/minimum.*greater.*maximum/i);
             }
-        })
-    })
+        });
+    });
 
     it('calls setTimeout with the correct duration', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const setTimeoutSpy = vi.spyOn(global, 'setTimeout')
+        const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
 
-        const action = new RandomWaitAction(2, 2) // predictable delay
-        const promise = action.execute()
-        vi.runAllTimers()
-        await promise
+        const action = new RandomWaitAction(2, 2); // predictable delay
+        const promise = action.execute();
+        vi.runAllTimers();
+        await promise;
 
-        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000)
-    })
-})
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000);
+    });
+});

--- a/__tests__/constants.test.ts
+++ b/__tests__/constants.test.ts
@@ -2,19 +2,19 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { describe, it, expect } from 'vitest'
-import { MAXIMUM_ALLOWED, MINIMUM_ALLOWED } from '../src/constants'
+import { describe, it, expect } from 'vitest';
+import { MAXIMUM_ALLOWED, MINIMUM_ALLOWED } from '../src/constants';
 
 describe('ensure constants are correctly set', () => {
     it('has correct maximum value', () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        expect(MAXIMUM_ALLOWED).toBe(120)
-    })
+        expect(MAXIMUM_ALLOWED).toBe(120);
+    });
 
     it('has correct minimum value', () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        expect(MINIMUM_ALLOWED).toBe(0)
-    })
-})
+        expect(MINIMUM_ALLOWED).toBe(0);
+    });
+});

--- a/__tests__/validateInputs.test.ts
+++ b/__tests__/validateInputs.test.ts
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { describe, it, expect } from 'vitest'
-import { validateInputs } from '../src/utils/validateInputs'
-import { InputValidationError } from '../src/utils/errors.ts'
-import fc from 'fast-check'
+import { describe, it, expect } from 'vitest';
+import { validateInputs } from '../src/utils/validateInputs';
+import { InputValidationError } from '../src/utils/errors.ts';
+import fc from 'fast-check';
 
 describe('validateInputs (unit cases)', () => {
     describe.each([
@@ -18,92 +18,92 @@ describe('validateInputs (unit cases)', () => {
         ['minimum greater than maximum', 11, 10, /greater than/]
     ])('%s', (_desc, min, max, expectedError) => {
         it(`should return error when min=${min}, max=${max}`, () => {
-            expect.hasAssertions()
+            expect.hasAssertions();
 
-            const result = validateInputs(min, max)
+            const result = validateInputs(min, max);
 
-            expect(result.isErr).toBe(true)
+            expect(result.isErr).toBe(true);
 
             result.match({
                 Ok: () => {
-                    throw new Error('Expected Err but got Ok')
+                    throw new Error('Expected Err but got Ok');
                 },
                 Err: error => {
-                    expect(error).toBeInstanceOf(InputValidationError)
-                    expect(error.message).toMatch(expectedError)
+                    expect(error).toBeInstanceOf(InputValidationError);
+                    expect(error.message).toMatch(expectedError);
                 }
-            })
-        })
-    })
+            });
+        });
+    });
 
     it('returns ok when inputs are valid', () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const result = validateInputs(5, 10)
+        const result = validateInputs(5, 10);
 
-        expect(result.isOk).toBe(true)
-    })
-})
+        expect(result.isOk).toBe(true);
+    });
+});
 
 describe('validateInputs (property-based)', () => {
     it('always returns ok for positive integers where min <= max', () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
         fc.assert(
             fc.property(
                 fc.integer({ min: 1, max: 1000 }),
                 fc.integer({ min: 1, max: 1000 }),
                 (a, b) => {
-                    const min = Math.min(a, b)
-                    const max = Math.max(a, b)
-                    const result = validateInputs(min, max)
+                    const min = Math.min(a, b);
+                    const max = Math.max(a, b);
+                    const result = validateInputs(min, max);
 
-                    expect(result.isOk).toBe(true)
+                    expect(result.isOk).toBe(true);
                 }
             )
-        )
-    })
+        );
+    });
 
     it('always returns error when min > max', () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
         fc.assert(
             fc.property(
                 fc.integer({ min: 1, max: 1000 }),
                 fc.integer({ min: 1, max: 1000 }),
                 (a, b) => {
-                    if (a <= b) return // skip valid cases
-                    const result = validateInputs(a, b)
+                    if (a <= b) return; // skip valid cases
+                    const result = validateInputs(a, b);
                     if (result.isErr) {
-                        expect(result.error.message).toMatch(/greater than/)
+                        expect(result.error.message).toMatch(/greater than/);
                     }
                 }
             )
-        )
-    })
+        );
+    });
 
     it('never accepts negative inputs', () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
         fc.assert(
             fc.property(
                 fc.integer({ max: -1 }),
                 fc.integer({ max: -1 }),
                 (min, max) => {
-                    const result = validateInputs(min, max)
+                    const result = validateInputs(min, max);
 
-                    expect(result.isErr).toBe(true)
+                    expect(result.isErr).toBe(true);
 
                     result.match({
                         Ok: () => {
-                            throw new Error('Expected Err but got Ok')
+                            throw new Error('Expected Err but got Ok');
                         },
                         Err: error => {
-                            expect(error.message).toMatch(/positive|greater/)
+                            expect(error.message).toMatch(/positive|greater/);
                         }
-                    })
+                    });
                 }
             )
-        )
-    })
-})
+        );
+    });
+});

--- a/__tests__/validateInputs.test.ts
+++ b/__tests__/validateInputs.test.ts
@@ -75,7 +75,6 @@ describe('validateInputs (property-based)', () => {
                     if (a <= b) return // skip valid cases
                     const result = validateInputs(a, b)
                     if (result.isErr) {
-                        // eslint-disable-next-line vitest/no-conditional-expect
                         expect(result.error.message).toMatch(/greater than/)
                     }
                 }

--- a/__tests__/wait.test.ts
+++ b/__tests__/wait.test.ts
@@ -2,127 +2,127 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { describe, it, expect, vi } from 'vitest'
-import { wait } from '../src/wait'
-import { InputValidationError } from '../src/utils/errors'
+import { describe, it, expect, vi } from 'vitest';
+import { wait } from '../src/wait';
+import { InputValidationError } from '../src/utils/errors';
 
-const timingBuffer = 1000 // milliseconds to account for timer inaccuracy and async delays
+const timingBuffer = 1000; // milliseconds to account for timer inaccuracy and async delays
 
 describe('wait (real setTimeout)', () => {
     it('resolves between 1 and 5 seconds', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const start = Date.now()
-        await wait(1, 5)
-        const end = Date.now()
+        const start = Date.now();
+        await wait(1, 5);
+        const end = Date.now();
 
-        const delta = end - start
+        const delta = end - start;
 
-        expect(delta).toBeGreaterThanOrEqual(1000)
-        expect(delta).toBeLessThanOrEqual(5000 + timingBuffer)
-    })
+        expect(delta).toBeGreaterThanOrEqual(1000);
+        expect(delta).toBeLessThanOrEqual(5000 + timingBuffer);
+    });
 
     it('resolves between 5 and 10 seconds', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const start = Date.now()
-        await wait(5, 10)
-        const end = Date.now()
+        const start = Date.now();
+        await wait(5, 10);
+        const end = Date.now();
 
-        const delta = end - start
+        const delta = end - start;
 
-        expect(delta).toBeGreaterThanOrEqual(5000)
-        expect(delta).toBeLessThanOrEqual(10000 + timingBuffer)
-    })
-})
+        expect(delta).toBeGreaterThanOrEqual(5000);
+        expect(delta).toBeLessThanOrEqual(10000 + timingBuffer);
+    });
+});
 
 describe('wait (mocked setTimeout)', () => {
     it('waits and resolves with a number string in range', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        vi.useFakeTimers()
-        const promise = wait(2, 4) // should pick 2, 3, or 4
+        vi.useFakeTimers();
+        const promise = wait(2, 4); // should pick 2, 3, or 4
         // advance time to max possible delay to ensure resolution
-        vi.advanceTimersByTime(4000)
+        vi.advanceTimersByTime(4000);
 
-        const result = await promise
+        const result = await promise;
 
         result.match({
             Ok: num => {
-                expect(typeof num).toBe('number')
-                expect(num).toBeGreaterThanOrEqual(2)
-                expect(num).toBeLessThanOrEqual(4)
+                expect(typeof num).toBe('number');
+                expect(num).toBeGreaterThanOrEqual(2);
+                expect(num).toBeLessThanOrEqual(4);
             },
             Err: () => {
-                throw new Error('Expected Ok but got Err')
+                throw new Error('Expected Ok but got Err');
             }
-        })
-        vi.useRealTimers()
-    })
-})
+        });
+        vi.useRealTimers();
+    });
+});
 
 describe('wait errors out on invalid inputs', () => {
     it('errors out if maximum is less than minimum', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const result = await wait(2, 0)
+        const result = await wait(2, 0);
 
         result.match({
             Ok: () => {
-                throw new Error('Expected Err but got Ok')
+                throw new Error('Expected Err but got Ok');
             },
             Err: error => {
-                expect(error).toBeInstanceOf(InputValidationError)
-                expect(error.message).toMatch(/minimum.*greater.*maximum/i)
+                expect(error).toBeInstanceOf(InputValidationError);
+                expect(error.message).toMatch(/minimum.*greater.*maximum/i);
             }
-        })
-    })
+        });
+    });
 
     it('errors out if both minimum and maximum are zero', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const result = await wait(0, 0)
+        const result = await wait(0, 0);
 
         result.match({
             Ok: () => {
-                throw new Error('Expected Err but got Ok')
+                throw new Error('Expected Err but got Ok');
             },
             Err: error => {
-                expect(error).toBeInstanceOf(InputValidationError)
-                expect(error.message).toMatch(/cannot be zero/i)
+                expect(error).toBeInstanceOf(InputValidationError);
+                expect(error.message).toMatch(/cannot be zero/i);
             }
-        })
-    })
+        });
+    });
 
     it('errors out if both minimum and maximum are not integers', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const result = await wait(2.5, 4.5)
+        const result = await wait(2.5, 4.5);
 
         result.match({
             Ok: () => {
-                throw new Error('Expected Err but got Ok')
+                throw new Error('Expected Err but got Ok');
             },
             Err: error => {
-                expect(error).toBeInstanceOf(InputValidationError)
-                expect(error.message).toMatch(/integers/i)
+                expect(error).toBeInstanceOf(InputValidationError);
+                expect(error.message).toMatch(/integers/i);
             }
-        })
-    })
+        });
+    });
 
     it('errors out if both minimum and maximum are not numbers', async () => {
-        expect.hasAssertions()
+        expect.hasAssertions();
 
-        const result = await wait('a', 'd')
+        const result = await wait('a', 'd');
 
         result.match({
             Ok: () => {
-                throw new Error('Expected Err but got Ok')
+                throw new Error('Expected Err but got Ok');
             },
             Err: error => {
-                expect(error).toBeInstanceOf(InputValidationError)
-                expect(error.message).toMatch(/numbers/i)
+                expect(error).toBeInstanceOf(InputValidationError);
+                expect(error.message).toMatch(/numbers/i);
             }
-        })
-    })
-})
+        });
+    });
+});

--- a/src/RandomWaitAction.ts
+++ b/src/RandomWaitAction.ts
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: MIT
 
 import { Result } from 'true-myth'
-import { wait } from './wait'
-import { validateInputs } from './utils/validateInputs'
-import { InputValidationError } from './utils/errors'
+import { wait } from './wait.js'
+import { validateInputs } from './utils/validateInputs.js'
+import { InputValidationError } from './utils/errors.js'
 
 export class RandomWaitAction {
     private readonly minimum: number

--- a/src/RandomWaitAction.ts
+++ b/src/RandomWaitAction.ts
@@ -2,18 +2,18 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { Result } from 'true-myth'
-import { wait } from './wait.js'
-import { validateInputs } from './utils/validateInputs.js'
-import { InputValidationError } from './utils/errors.js'
+import { Result } from 'true-myth';
+import { wait } from './wait.js';
+import { validateInputs } from './utils/validateInputs.js';
+import { InputValidationError } from './utils/errors.js';
 
 export class RandomWaitAction {
-    private readonly minimum: number
-    private readonly maximum: number
+    private readonly minimum: number;
+    private readonly maximum: number;
 
     constructor(minimum: number, maximum: number) {
-        this.minimum = minimum
-        this.maximum = maximum
+        this.minimum = minimum;
+        this.maximum = maximum;
     }
 
     /**
@@ -21,11 +21,11 @@ export class RandomWaitAction {
      * @returns Promise resolving to a Result wrapping the number of seconds waited, or an error.
      */
     public async execute(): Promise<Result<number, InputValidationError>> {
-        const validationResult = validateInputs(this.minimum, this.maximum)
+        const validationResult = validateInputs(this.minimum, this.maximum);
         if (validationResult.isErr) {
-            return Result.err(validationResult.error)
+            return Result.err(validationResult.error);
         }
 
-        return wait(this.minimum, this.maximum)
+        return wait(this.minimum, this.maximum);
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 // Set the minimum time limit to 0 seconds
-export const MINIMUM_ALLOWED = 0
+export const MINIMUM_ALLOWED = 0;
 
 // Set the maximum time limit to 2 minutes (120 seconds)
-export const MAXIMUM_ALLOWED = 120
+export const MAXIMUM_ALLOWED = 120;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,41 +2,41 @@
 //
 // SPDX-License-Identifier: MIT
 
-import * as core from '@actions/core'
-import { Maybe } from 'true-myth'
-import { RandomWaitAction } from './RandomWaitAction.js'
-import { MAXIMUM_ALLOWED, MINIMUM_ALLOWED } from './constants.js'
+import * as core from '@actions/core';
+import { Maybe } from 'true-myth';
+import { RandomWaitAction } from './RandomWaitAction.js';
+import { MAXIMUM_ALLOWED, MINIMUM_ALLOWED } from './constants.js';
 
 async function run(): Promise<void> {
     try {
         // Retrieve input values from GitHub Action inputs
-        const minInput = core.getInput('minimum')
-        const maxInput = core.getInput('maximum')
+        const minInput = core.getInput('minimum');
+        const maxInput = core.getInput('maximum');
 
         // Use Maybe to safely parse inputs into numbers
-        const minimum = Maybe.of(minInput).mapOr(MINIMUM_ALLOWED, parseInt)
-        const maximum = Maybe.of(maxInput).mapOr(MAXIMUM_ALLOWED, parseInt)
+        const minimum = Maybe.of(minInput).mapOr(MINIMUM_ALLOWED, parseInt);
+        const maximum = Maybe.of(maxInput).mapOr(MAXIMUM_ALLOWED, parseInt);
 
         // Create instance of pure business logic class
-        const action = new RandomWaitAction(minimum, maximum)
+        const action = new RandomWaitAction(minimum, maximum);
         core.debug(
             `Executing random wait between ${minimum} and ${maximum} seconds...`
-        )
-        core.debug(`Start Time: ${new Date().toTimeString()}`)
+        );
+        core.debug(`Start Time: ${new Date().toTimeString()}`);
 
         // Execute the wait logic
-        const result = await action.execute()
+        const result = await action.execute();
         if (result.isErr) {
-            core.setFailed(result.error.message)
-            return
+            core.setFailed(result.error.message);
+            return;
         }
 
-        const waitTime = result.value
-        core.debug(`End Time: ${new Date().toTimeString()}`)
-        core.setOutput('wait_time', waitTime.toString())
+        const waitTime = result.value;
+        core.debug(`End Time: ${new Date().toTimeString()}`);
+        core.setOutput('wait_time', waitTime.toString());
     } catch (error) {
-        if (error instanceof Error) core.setFailed(error.message)
+        if (error instanceof Error) core.setFailed(error.message);
     }
 }
 
-void run()
+void run();

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,8 @@
 
 import * as core from '@actions/core'
 import { Maybe } from 'true-myth'
-import { RandomWaitAction } from './RandomWaitAction'
-import { MAXIMUM_ALLOWED, MINIMUM_ALLOWED } from './constants'
+import { RandomWaitAction } from './RandomWaitAction.js'
+import { MAXIMUM_ALLOWED, MINIMUM_ALLOWED } from './constants.js'
 
 async function run(): Promise<void> {
     try {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -5,7 +5,7 @@
 // src/utils/errors.ts
 export class InputValidationError extends Error {
     constructor(message: string) {
-        super(message)
-        this.name = 'InputValidationError'
+        super(message);
+        this.name = 'InputValidationError';
     }
 }

--- a/src/utils/validateInputs.ts
+++ b/src/utils/validateInputs.ts
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MIT
 
 // src/utils/validateInputs.ts
-import { Result, Unit } from 'true-myth'
-import { InputValidationError } from './errors.js'
+import { Result, Unit } from 'true-myth';
+import { InputValidationError } from './errors.js';
 
 /**
  * Validates the input values.
@@ -21,7 +21,7 @@ export function validateInputs(
             new InputValidationError(
                 'Both minimum and maximum must be numbers.'
             )
-        )
+        );
     }
 
     if (!Number.isInteger(minimum) || !Number.isInteger(maximum)) {
@@ -29,13 +29,13 @@ export function validateInputs(
             new InputValidationError(
                 'Both minimum and maximum must be integers.'
             )
-        )
+        );
     }
 
     if (minimum == 0 && maximum == 0) {
         return Result.err(
             new InputValidationError('Both minimum and maximum cannot be zero.')
-        )
+        );
     }
 
     if (minimum < 0 || maximum < 0) {
@@ -43,12 +43,12 @@ export function validateInputs(
             new InputValidationError(
                 'Both minimum and maximum must be positive integers.'
             )
-        )
+        );
     }
     if (minimum > maximum) {
         return Result.err(
             new InputValidationError('Minimum cannot be greater than maximum.')
-        )
+        );
     }
-    return Result.ok(Unit)
+    return Result.ok(Unit);
 }

--- a/src/utils/validateInputs.ts
+++ b/src/utils/validateInputs.ts
@@ -4,7 +4,7 @@
 
 // src/utils/validateInputs.ts
 import { Result, Unit } from 'true-myth'
-import { InputValidationError } from './errors'
+import { InputValidationError } from './errors.js'
 
 /**
  * Validates the input values.

--- a/src/wait.ts
+++ b/src/wait.ts
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { Result } from 'true-myth'
-import { validateInputs } from './utils/validateInputs.js'
-import { InputValidationError } from './utils/errors.js'
+import { Result } from 'true-myth';
+import { validateInputs } from './utils/validateInputs.js';
+import { InputValidationError } from './utils/errors.js';
 
 /**
  * Waits for a random number of seconds between minimum and maximum.
@@ -16,15 +16,15 @@ export async function wait(
     minimum: number,
     maximum: number
 ): Promise<Result<number, InputValidationError>> {
-    const validation = validateInputs(minimum, maximum)
+    const validation = validateInputs(minimum, maximum);
     if (validation.isErr) {
-        return Result.err(validation.error)
+        return Result.err(validation.error);
     }
 
-    const secs = Math.floor(Math.random() * (maximum - minimum + 1)) + minimum
+    const secs = Math.floor(Math.random() * (maximum - minimum + 1)) + minimum;
     return new Promise(resolve => {
         setTimeout(() => {
-            resolve(Result.ok(secs))
-        }, secs * 1000)
-    })
+            resolve(Result.ok(secs));
+        }, secs * 1000);
+    });
 }

--- a/src/wait.ts
+++ b/src/wait.ts
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: MIT
 
 import { Result } from 'true-myth'
-import { validateInputs } from './utils/validateInputs'
-import { InputValidationError } from './utils/errors'
+import { validateInputs } from './utils/validateInputs.js'
+import { InputValidationError } from './utils/errors.js'
 
 /**
  * Waits for a random number of seconds between minimum and maximum.


### PR DESCRIPTION
# Add semicolons to all statements

This PR updates the Prettier configuration to require semicolons at the end of statements by changing the `semi` option from `false` to `true`. It then applies this change across all TypeScript files in the codebase, adding semicolons to the end of each statement.

Additionally, it updates import paths to use the `.js` extension for better ESM compatibility.

Signed-off-by: Ali Sajid Imami <395482+AliSajid@users.noreply.github.com>