### PR TITLE
build: update the eslint and tsconfig configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ styles/*
 
 # Scripts
 !scripts/
+
+!tsconfig.base.json

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,105 +2,54 @@
 //
 // SPDX-License-Identifier: MIT
 
-import eslint from '@eslint/js'
-import tseslint from 'typescript-eslint'
-import stylistic from '@stylistic/eslint-plugin'
-import vitest from '@vitest/eslint-plugin'
-import globals from 'globals'
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import stylistic from '@stylistic/eslint-plugin';
+import vitest from '@vitest/eslint-plugin';
 
 export default tseslint.config(
+    eslint.configs.recommended,
+    tseslint.configs.recommended,
     {
         ignores: [
-            '**/dist/**',
-            '**/lib/**',
-            'docs/**'
+            'dist/',
+            'lib/',
+            '*.config.[tj]s'
         ]
     },
-    eslint.configs.recommended,
+    {
+        files: ['*.ts'],
+        languageOptions: {
+            parserOptions: {
+                project: './tsconfig.eslint.json',
+                tsconfigRootDir: import.meta.dirname
+            }
+        }
+    },
+
+    tseslint.configs.stylistic,
+
     {
         plugins: {
-            '@typescript-eslint': tseslint.plugin,
             '@stylistic': stylistic
         },
-
-        languageOptions: {
-            globals: {
-                ...globals.node
-            },
-
-            parser: tseslint.parser,
-            ecmaVersion: 9,
-            sourceType: 'module',
-
-            parserOptions: {
-                project: './tsconfig.eslint.json'
-            }
-        },
-
         rules: {
-            '@typescript-eslint/array-type': 'error',
-            '@typescript-eslint/await-thenable': 'error',
-            '@typescript-eslint/ban-ts-comment': 'error',
-            '@typescript-eslint/consistent-type-assertions': 'error',
-
-            '@typescript-eslint/explicit-function-return-type': [
-                'error',
-                {
-                    allowExpressions: true
-                }
-            ],
-
-            '@typescript-eslint/explicit-member-accessibility': [
-                'error',
-                {
-                    accessibility: 'no-public'
-                }
-            ],
-
-            '@stylistic/func-call-spacing': ['error', 'never'],
-            '@typescript-eslint/no-array-constructor': 'error',
-            '@typescript-eslint/no-empty-interface': 'error',
-            '@typescript-eslint/no-explicit-any': 'error',
-            '@typescript-eslint/no-extraneous-class': 'error',
-            '@typescript-eslint/no-for-in-array': 'error',
-            '@typescript-eslint/no-inferrable-types': 'error',
-            '@typescript-eslint/no-misused-new': 'error',
-            '@typescript-eslint/no-namespace': 'error',
-            '@typescript-eslint/no-non-null-assertion': 'warn',
-            '@typescript-eslint/no-require-imports': 'error',
-            '@typescript-eslint/no-unnecessary-qualifier': 'error',
-            '@typescript-eslint/no-unnecessary-type-assertion': 'error',
-            '@typescript-eslint/no-unused-vars': 'error',
-            '@typescript-eslint/no-useless-constructor': 'error',
-            '@typescript-eslint/no-var-requires': 'error',
-            '@typescript-eslint/prefer-for-of': 'warn',
-            '@typescript-eslint/prefer-function-type': 'warn',
-            '@typescript-eslint/prefer-includes': 'error',
-            '@typescript-eslint/prefer-string-starts-ends-with': 'error',
-            '@typescript-eslint/promise-function-async': 'error',
-            '@typescript-eslint/require-array-sort-compare': 'error',
-            '@typescript-eslint/restrict-plus-operands': 'error',
-            '@stylistic/semi': ['error', 'never'],
-            '@stylistic/type-annotation-spacing': 'error',
-            '@typescript-eslint/unbound-method': 'error',
-            camelcase: 'off',
-            'eslint-comments/no-use': 'off',
-            'i18n-text/no-en': 'off',
-            'import/no-namespace': 'off',
-            'no-unused-vars': 'off',
-            semi: 'off'
+            // stylistic recommendations (edit as needed)
+            '@stylistic/indent': ['error', 4],
+            '@stylistic/semi': ['error', 'always'],
+            '@stylistic/quotes': ['error', 'single'],
+            '@stylistic/comma-dangle': ['error', 'always-multiline']
         }
     },
+
     {
-        files: ['**/*.js', '**/*.cjs', '**/*.mjs'],
-        ...tseslint.configs.disableTypeChecked
-    },
-    {
-        files: ['__tests__/*.test.ts'],
-        plugins: { vitest },
+        files: ['__tests__/**', 'src/**/*.spec.ts'], // or any other pattern
+        plugins: {
+            vitest
+        },
         rules: {
-            ...vitest.configs.all.rules,
-            'vitest/max-nested-describe': ['error', { max: 3 }]
+            ...vitest.configs.recommended.rules, // you can also use vitest.configs.all.rules to enable all rules
+            'vitest/max-nested-describe': ['error', { max: 3 }] // you can also modify rules' behavior using option like this
         }
     }
-)
+);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true,
+        "declaration": false,
+        "declarationMap": false,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "lib": [
+            "ES2022"
+        ],
+        "module": "NodeNext",
+        "moduleDetection": "force",
+        "moduleResolution": "NodeNext",
+        "newLine": "lf",
+        "noImplicitAny": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": false,
+        "pretty": true,
+        "resolveJsonModule": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "strictNullChecks": true,
+        "target": "ES2022"
+    }
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,12 +1,21 @@
 {
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "compilerOptions": {
+        "allowJs": true,
+        "noEmit": true
+    },
     "exclude": [
         "dist",
+        "coverage",
         "node_modules",
-        "docs"
+        "lib"
     ],
-    "extends": "./tsconfig.json",
+    "extends": "./tsconfig.base.json",
     "include": [
+        "__fixtures__",
+        "__tests__",
         "src",
-        "__tests__"
+        "eslint.config.mjs",
+        "rollup.config.ts"
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,21 @@
 {
+    "$schema": "https://json.schemastore.org/tsconfig",
     "compilerOptions": {
-        "baseUrl": "./docs",
-        "esModuleInterop": true,
-        "module": "ESNext",
-        "moduleDetection": "force",
-        "moduleResolution": "bundler",
-        "noImplicitAny": true,
-        "outDir": "lib",
-        "rootDir": "src",
-        "skipLibCheck": true,
-        "strict": true,
-        "target": "ESNext"
+        "baseUrl": "./",
+        "outDir": "./dist",
+        "rootDir": "src"
     },
     "exclude": [
         "node_modules",
-        "**/*.test.ts",
+        "__fixtures__",
+        "coverage",
+        "dist",
         "megalinter-reports/**/*.js",
         "vitest.config.ts",
         "docs"
+    ],
+    "extends": "./tsconfig.base.json",
+    "include": [
+        "src"
     ]
 }


### PR DESCRIPTION
### TL;DR

Modernized TypeScript and ESLint configuration with improved project structure.

### What changed?

- Added `tsconfig.base.json` as a shared configuration file for TypeScript settings
- Updated `.gitignore` to explicitly include the new base TypeScript config
- Completely refactored `eslint.config.mjs` to use a more modular approach:
  - Simplified configuration with proper file patterns
  - Added stylistic rules with consistent formatting (4-space indentation, single quotes, trailing commas)
  - Improved test file detection for Vitest
- Updated `tsconfig.eslint.json` to extend from the new base config
- Restructured `tsconfig.json` to be more focused on the source code

### How to test?

1. Run ESLint to verify the new configuration works: `npx eslint .`
2. Compile the TypeScript code to ensure the new configuration is valid: `tsc --noEmit`
3. Run tests to confirm the Vitest configuration is working properly

### Why make this change?

This change establishes a more maintainable and modular TypeScript/ESLint configuration. By creating a base TypeScript configuration that can be extended, we reduce duplication and make it easier to maintain consistent settings across different parts of the project. The ESLint configuration has been modernized to follow current best practices, with better organization of rules and more precise file targeting.