### PR TITLE
build: update the pnpm run scripts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,6 @@
 
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
-import stylistic from '@stylistic/eslint-plugin';
 import vitest from '@vitest/eslint-plugin';
 
 export default tseslint.config(
@@ -28,19 +27,6 @@ export default tseslint.config(
     },
 
     tseslint.configs.stylistic,
-
-    {
-        plugins: {
-            '@stylistic': stylistic
-        },
-        rules: {
-            // stylistic recommendations (edit as needed)
-            '@stylistic/indent': ['error', 4],
-            '@stylistic/semi': ['error', 'always'],
-            '@stylistic/quotes': ['error', 'single'],
-            '@stylistic/comma-dangle': ['error', 'always-multiline']
-        }
-    },
 
     {
         files: ['__tests__/**', 'src/**/*.spec.ts'], // or any other pattern

--- a/package.json
+++ b/package.json
@@ -49,12 +49,12 @@
         "url": "git+https://github.com/AliSajid/random-wait-action"
     },
     "scripts": {
-        "all": "pnpm run build && pnpm run format && pnpm run lint && pnpm run package && pnpm test",
-        "build": "tsc",
-        "format": "prettier --write '{src,docs}/**/*.{ts,js,json,md,yaml,yml}'",
-        "format-check": "prettier --check '{src,docs}/**/*.{ts,js,json,md,yaml,yml}'",
-        "lint": "eslint",
-        "package": "ncc build --source-map --license licenses.txt",
+        "all": "pnpm run format:check && pnpm run lint:check && pnpm run test && pnpm run package",
+        "format:check": "prettier --check '{src,docs}/**/*.{ts,js,json,md,yaml,yml}'",
+        "format:write": "prettier --write '{src,docs}/**/*.{ts,js,json,md,yaml,yml}'",
+        "lint:check": "pnpx eslint .",
+        "lint:fix": "pnpx eslint . --fix",
+        "package": "pnpx rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
         "test": "vitest --run",
         "test:coverage": "vitest --coverage"
     },


### PR DESCRIPTION
### TL;DR

Removed stylistic ESLint plugin and updated npm scripts for better development workflow.

### What changed?

- Removed the `@stylistic/eslint-plugin` dependency and its configuration from `eslint.config.mjs`
- Renamed and improved npm scripts in `package.json`:
  - Renamed `format` to `format:write` and `format-check` to `format:check`
  - Added `lint:fix` script to automatically fix linting issues
  - Changed `lint` to `lint:check` with proper command to lint all files
  - Replaced `ncc build` with Rollup for packaging
  - Removed the explicit `build` script
  - Updated the `all` script to run format check, lint check, tests, and packaging

### How to test?

1. Run `pnpm all` to verify the new workflow works correctly
2. Test individual commands:
   - `pnpm format:check` to check formatting
   - `pnpm format:write` to apply formatting
   - `pnpm lint:check` to check for linting issues
   - `pnpm lint:fix` to automatically fix linting issues
   - `pnpm package` to build the package with Rollup

### Why make this change?

This change streamlines the development workflow by:
- Simplifying the ESLint configuration by relying on TypeScript ESLint's built-in stylistic rules
- Providing more intuitive script names with clear purposes
- Using Rollup instead of ncc for more flexible bundling
- Creating a more consistent naming convention for scripts (check/write, check/fix)