### PR TITLE
ci(release): update release permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,6 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-      contents: write
       issues: write
       pull-requests: write
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
           subject-path: dist/index.js
 
       - name: Move attestation file to dist/
-        run: mv ${{ steps.attest.outputs.bundle-path }} dist/attestation.jsonl
+        run: mv ${{ steps.attest.outputs.bundle-path }} dist/attestation.intoto.jsonl
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0


### PR DESCRIPTION
Removed `contents: write` permission from the release workflow.

Signed-off-by: Ali Sajid Imami <395482+AliSajid@users.noreply.github.com>