### PR TITLE
ci(scorecard): update the scorecard to use contents-read instead of read-all

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -6,7 +6,8 @@ on:
   push:
     branches: ["next"]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:

--- a/.github/workflows/sonar-cloud.yaml
+++ b/.github/workflows/sonar-cloud.yaml
@@ -12,8 +12,6 @@ permissions:
 
 jobs:
   sonarcloud:
-    permissions:
-      contents: read # for actions/checkout to fetch code
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### TL;DR

Updated permissions in the GitHub Actions scorecard workflow.

### What changed?

Changed the permissions configuration in the `.github/workflows/scorecard.yaml` file from a general `read-all` permission to a more specific `contents: read` permission.

### How to test?

Run the GitHub Actions scorecard workflow on a branch to verify it executes correctly with the updated permissions.

### Why make this change?

This change follows the principle of least privilege by specifying only the exact permission needed (read access to repository contents) rather than granting read access to all scopes. This improves the security posture of the workflow by limiting its access to only what's necessary.