### PR TITLE
ci(sonarcloud): removed joblevel read permission

### DIFF
--- a/.github/workflows/sonar-cloud.yaml
+++ b/.github/workflows/sonar-cloud.yaml
@@ -12,8 +12,6 @@ permissions:
 
 jobs:
   sonarcloud:
-    permissions:
-      contents: read # for actions/checkout to fetch code
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### TL;DR

Removed redundant permissions declaration in the SonarCloud GitHub workflow.

### What changed?

Removed the nested `permissions` block with `contents: read` from the `sonarcloud` job in the `.github/workflows/sonar-cloud.yaml` file. This permission was already defined at the top level of the workflow.

### How to test?

1. Verify that the GitHub workflow runs successfully when triggered
2. Confirm that the SonarCloud job still has proper access to checkout the repository code

### Why make this change?

The permissions were already defined at the workflow level with `contents: read`, making the job-level permission declaration redundant. This change simplifies the workflow configuration while maintaining the same functionality.