### PR TITLE
ci(release): allow the release workflow to avoid rule violations

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,4 +75,4 @@ jobs:
             @semantic-release/exec@6
             @semantic-release/git@10
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_GITHUB }}


### PR DESCRIPTION
### TL;DR

Updated GitHub token used in the release workflow to use PAT_GITHUB instead of the default GITHUB_TOKEN.

### What changed?

Changed the environment variable in the release.yaml workflow from using the default `secrets.GITHUB_TOKEN` to using `secrets.PAT_GITHUB` (Personal Access Token) for GitHub authentication.

### How to test?

1. Verify that the PAT_GITHUB secret is properly configured in the repository settings
2. Trigger the release workflow to ensure it can properly authenticate with GitHub
3. Confirm that all semantic-release actions complete successfully

### Why make this change?

The default GITHUB_TOKEN has limited permissions that may prevent certain operations during the release process. Using a Personal Access Token (PAT) provides additional permissions needed for the semantic-release process to function correctly, such as creating releases, pushing tags, or triggering other workflows.