### PR TITLE
chore: merge development train

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,8 +13,8 @@ on:
         inputs:
             release_branch:
                 description: >
-                    Branch to run the release workflow against. Only main and next
-                    can publish; every other branch is forced to dry-run.
+                    Branch to run the release workflow against. Only main and next can
+                    publish; every other branch is forced to dry-run.
                 required: true
                 default: 'main'
                 type: string
@@ -223,6 +223,7 @@ jobs:
 
             - name: Prepare release files in isolated Cocogitto clone
               if: steps.has_changes.outputs.has_changes == 'true'
+              id: prepare
               env:
                   VERSION: ${{ steps.version.outputs.version }}
                   PRE_RELEASE: ${{ steps.release_type.outputs.pre_release }}
@@ -300,10 +301,23 @@ jobs:
 
                   CHANGED_FILES="$(git diff --name-only)"
 
+                  # Copy release notes out of the disposable clone before any early exit.
+                  cp "$TMP_DIR/release_notes.md" /tmp/release_notes.md
+
                   if [ -z "$CHANGED_FILES" ]; then
-                      echo "::error::Cocogitto produced no release file changes."
-                      exit 1
+                      echo "has_file_changes=false" >> "$GITHUB_OUTPUT"
+                      echo "No release file changes were produced."
+                      echo "package.json and CHANGELOG.md already appear to contain $VERSION_TAG / $VERSION."
+                      echo "The workflow will treat this as an already-prepared release and,"
+                      echo "for non-dry-run runs,tag the current branch HEAD."
+                      echo
+                      echo "Generated release notes:"
+                      echo
+                      cat /tmp/release_notes.md
+                      exit 0
                   fi
+
+                  echo "has_file_changes=true" >> "$GITHUB_OUTPUT"
 
                   ALLOWED='^(CHANGELOG\.md|package\.json)$'
                   BAD_FILES="$(echo "$CHANGED_FILES" | grep -Ev "$ALLOWED" || true)"
@@ -328,15 +342,13 @@ jobs:
                       tar -xf "$TMP_DIR/release-files.tar" -C "$GITHUB_WORKSPACE"
                   fi
 
-                  cp "$TMP_DIR/release_notes.md" /tmp/release_notes.md
-
                   echo
                   echo "Generated release notes:"
                   echo
                   cat /tmp/release_notes.md
 
             - name: Validate release file changes
-              if: steps.has_changes.outputs.has_changes == 'true'
+              if: steps.has_changes.outputs.has_changes == 'true' && steps.prepare.outputs.has_file_changes == 'true'
               run: |
                   set -euo pipefail
 
@@ -368,12 +380,21 @@ jobs:
                   echo "Target branch: ${{ steps.branch.outputs.branch }}"
                   echo "Pre-release:   ${{ steps.release_type.outputs.pre_release }}"
                   echo "Version:       ${{ steps.version.outputs.version }}"
+                  echo "File changes:  ${{ steps.prepare.outputs.has_file_changes }}"
                   echo
-                  echo "Changed files:"
-                  git diff --name-only
+                  if [ "${{ steps.prepare.outputs.has_file_changes }}" = "true" ]; then
+                      echo "Changed files:"
+                      git diff --name-only
+                  else
+                      echo "No release file changes were needed; package.json and CHANGELOG.md were already prepared."
+                  fi
                   echo
                   echo "Diff:"
-                  git diff -- CHANGELOG.md package.json || true
+                  if [ "${{ steps.prepare.outputs.has_file_changes }}" = "true" ]; then
+                      git diff -- CHANGELOG.md package.json || true
+                  else
+                      echo "No diff."
+                  fi
                   echo
                   echo "Release notes:"
                   cat /tmp/release_notes.md
@@ -396,7 +417,9 @@ jobs:
                   echo "Remote tag $VERSION_TAG does not exist."
 
             - name: Create verified release commit
-              if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
+              if: steps.has_changes.outputs.has_changes == 'true' &&
+                  steps.prepare.outputs.has_file_changes == 'true' &&
+                  steps.mode.outputs.dry_run == 'false'
               id: release_commit
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               env:
@@ -432,7 +455,7 @@ jobs:
 
                       if (unexpectedFiles.length > 0) {
                         core.setFailed(
-                          `Release commit may only change CHANGELOG.md and package.json.
+                          `Release commit may only change CHANGELOG.md and package.json. \
                            Unexpected files: ${unexpectedFiles.join(", ")}`,
                         );
                         return;
@@ -506,27 +529,47 @@ jobs:
                       core.setOutput("sha", oid);
                       core.setOutput("url", url);
 
-            - name: Verify release commit was created
+            - name: Determine release target commit
+              if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
+              id: release_target
+              run: |
+                  set -euo pipefail
+
+                  if [ "${{ steps.prepare.outputs.has_file_changes }}" = "true" ]; then
+                      TARGET_SHA="${{ steps.release_commit.outputs.sha }}"
+                      if [ -z "$TARGET_SHA" ]; then
+                          echo "::error::Release commit SHA is empty. Commit creation may have failed."
+                          exit 1
+                      fi
+                      echo "Using newly-created release commit: $TARGET_SHA"
+                  else
+                      TARGET_SHA="$(git rev-parse HEAD)"
+                      echo "No release file changes were needed. Using current branch HEAD as release target: $TARGET_SHA"
+                  fi
+
+                  echo "sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+
+            - name: Verify release target commit exists
               if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
               env:
                   GH_TOKEN: ${{ steps.app_token.outputs.token }}
               run: |
                   set -euo pipefail
 
-                  EXPECTED_SHA="${{ steps.release_commit.outputs.sha }}"
+                  EXPECTED_SHA="${{ steps.release_target.outputs.sha }}"
 
                   if [ -z "$EXPECTED_SHA" ]; then
-                      echo "::error::Release commit SHA is empty. Commit creation may have failed."
+                      echo "::error::Release target SHA is empty."
                       exit 1
                   fi
 
-                  # Verify the commit exists on the remote via API.
+                  # Verify the target commit exists on the remote via API.
                   gh api repos/${{ github.repository }}/commits/"$EXPECTED_SHA" --jq '.sha' >/dev/null 2>&1 || {
-                      echo "::error::Could not verify release commit $EXPECTED_SHA on remote."
+                      echo "::error::Could not verify release target commit $EXPECTED_SHA on remote."
                       exit 1
                   }
 
-                  echo "Release commit $EXPECTED_SHA verified on remote."
+                  echo "Release target commit $EXPECTED_SHA verified on remote."
 
             - name: Refresh checkout to release commit
               if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
@@ -541,16 +584,16 @@ jobs:
                   git reset --hard "origin/$BASE_REF"
 
                   CURRENT_SHA="$(git rev-parse HEAD)"
-                  EXPECTED_SHA="${{ steps.release_commit.outputs.sha }}"
+                  EXPECTED_SHA="${{ steps.release_target.outputs.sha }}"
 
                   if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
-                      echo "::error::Local checkout is not at the release commit."
+                      echo "::error::Local checkout is not at the release target commit."
                       echo "Current:  $CURRENT_SHA"
                       echo "Expected: $EXPECTED_SHA"
                       exit 1
                   fi
 
-                  echo "Checkout refreshed to release commit: $CURRENT_SHA"
+                  echo "Checkout refreshed to release target commit: $CURRENT_SHA"
 
             - name: Create local semver tags
               if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
@@ -562,7 +605,7 @@ jobs:
 
                   SHOULD_MOVE_TAGS=false
                   if [ "${{ steps.branch.outputs.branch }}" = "main" ] &&
-                  [ "${{ steps.release_type.outputs.pre_release }}" = "false" ]; then
+                     [ "${{ steps.release_type.outputs.pre_release }}" = "false" ]; then
                       SHOULD_MOVE_TAGS=true
                   fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,7 +110,7 @@ jobs:
               uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
               with:
                   disable-sudo: true
-                  egress-policy: enforce
+                  egress-policy: block
                   disable-core-dump: true
                   allowed-endpoints: >
                       api.github.com:443
@@ -163,7 +163,7 @@ jobs:
 
             - name: Create GitHub App token
               id: app_token
-              uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
               with:
                   app-id: ${{ vars.RELEASE_APP_ID }}
                   private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -421,7 +421,7 @@ jobs:
                   steps.prepare.outputs.has_file_changes == 'true' &&
                   steps.mode.outputs.dry_run == 'false'
               id: release_commit
-              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
               env:
                   BASE_REF: ${{ steps.branch.outputs.branch }}
                   VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,21 @@ on:
             - main
             - next
 
+    workflow_dispatch:
+        inputs:
+            release_branch:
+                description: >
+                    Branch to run the release workflow against. Only main and next
+                    can publish; every other branch is forced to dry-run.
+                required: true
+                default: 'main'
+                type: string
+            dry_run:
+                description: 'Prepare the release but do not create commits, tags, or GitHub releases'
+                required: true
+                default: false
+                type: boolean
+
 name: Release
 
 permissions: {}
@@ -21,15 +36,75 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
+    validate-pr-author:
+        name: Validate PR Author
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == true
+        permissions:
+            contents: read
+            pull-requests: read
+        outputs:
+            is_valid: ${{ steps.validate.outputs.is_valid }}
+        steps:
+            - name: Check PR author
+              id: validate
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  AUTHOR: ${{ github.event.pull_request.user.login }}
+                  AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+              run: |
+                  # GitHub's web editor attributes commits to "web-flow"; never let a
+                  # PR "authored" by that identity trigger a release.
+                  if [ "$AUTHOR" = "web-flow" ]; then
+                      echo "::error::GitHub web-flow PRs are not allowed to trigger releases."
+                      echo "is_valid=false" >> "$GITHUB_OUTPUT"
+                      exit 1
+                  fi
+
+                  # Fast-fail obviously untrusted associations before calling the API.
+                  if [ "$AUTHOR_ASSOCIATION" = "NONE" ] || [ "$AUTHOR_ASSOCIATION" = "FIRST_TIME_CONTRIBUTOR" ]; then
+                      echo "::error::PR author '$AUTHOR' association '$AUTHOR_ASSOCIATION' is not trusted."
+                      echo "is_valid=false" >> "$GITHUB_OUTPUT"
+                      exit 1
+                  fi
+
+                  # Defense in depth: confirm current collaborator status directly.
+                  if gh api "repos/${{ github.repository }}/collaborators/$AUTHOR" >/dev/null 2>&1; then
+                      echo "PR author '$AUTHOR' validated as repository collaborator."
+                      echo "is_valid=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "::error::PR author '$AUTHOR' is not a repository collaborator. Release aborted."
+                      echo "is_valid=false" >> "$GITHUB_OUTPUT"
+                      exit 1
+                  fi
+
     release:
         name: Cocogitto Release
         runs-on: ubuntu-latest
-        if: "github.event.pull_request.merged == true && !contains(github.event.pull_request.title, '[skip ci]')"
+        needs: validate-pr-author
+        timeout-minutes: 20
+
+        if: >
+            always() &&
+            (
+                (
+                    github.event_name == 'pull_request_target' &&
+                    github.event.pull_request.merged == true &&
+                    !contains(github.event.pull_request.title, '[skip ci]') &&
+                    needs.validate-pr-author.outputs.is_valid == 'true'
+                ) ||
+                github.event_name == 'workflow_dispatch'
+            )
+
         permissions:
             contents: write
+
         outputs:
             version: ${{ steps.version.outputs.version }}
             has_changes: ${{ steps.has_changes.outputs.has_changes }}
+            branch: ${{ steps.branch.outputs.branch }}
+            pre_release: ${{ steps.release_type.outputs.pre_release }}
+
         steps:
             - name: Harden Runner
               uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -88,7 +163,7 @@ jobs:
 
             - name: Create GitHub App token
               id: app_token
-              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
               with:
                   app-id: ${{ vars.RELEASE_APP_ID }}
                   private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -97,22 +172,8 @@ jobs:
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   fetch-depth: 0
-
-            - name: Import GPG key
-              uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
-              with:
-                  gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-                  passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
-                  fingerprint: ${{ secrets.GPG_SUBKEY_FINGERPRINT }}
-                  trust_level: 5
-                  git_user_signingkey: true
-                  git_commit_gpgsign: true
-                  git_tag_gpgsign: false
-                  git_committer_name: ${{ vars.GIT_AUTHOR_NAME }}
-                  git_committer_email: ${{ vars.GIT_AUTHOR_EMAIL }}
-
-            - name: Test GPG Key Import
-              run: gpg --list-keys --keyid-format LONG
+                  ref: ${{ steps.branch.outputs.branch }}
+                  token: ${{ steps.app_token.outputs.token }}
 
             - name: Install mise
               uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
@@ -126,74 +187,455 @@ jobs:
             - name: Check for releasable changes
               id: has_changes
               run: |
-                  if cog log | grep -q .; then
-                      echo "has_changes=true" >> $GITHUB_OUTPUT
+                  set -euo pipefail
+
+                  CURRENT="$(cog -v get-version | sed 's/^v//')"
+
+                  if [ "${{ steps.release_type.outputs.pre_release }}" = "true" ]; then
+                      EXPECTED="$(cog bump --auto --dry-run --pre --skip-untracked | sed 's/^v//')"
                   else
-                      echo "has_changes=false" >> $GITHUB_OUTPUT
+                      EXPECTED="$(cog bump --auto --dry-run --skip-untracked | sed 's/^v//')"
                   fi
 
-            - name: Determine release type
-              id: release_type
-              run: |
-                  if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-                      echo "pre_release=false" >> $GITHUB_OUTPUT
+                  echo "current=${CURRENT}" >> "$GITHUB_OUTPUT"
+                  echo "Current Release Version: ${CURRENT}"
+                  echo "expected=${EXPECTED}" >> "$GITHUB_OUTPUT"
+                  echo "Calculated Release Version: ${EXPECTED}"
+
+                  if [ "$CURRENT" != "$EXPECTED" ]; then
+                      echo "has_changes=true" >> "$GITHUB_OUTPUT"
+                      echo "Unreleased changes found."
+                      echo "Proceeding to release"
                   else
-                      echo "pre_release=true" >> $GITHUB_OUTPUT
+                      echo "has_changes=false" >> "$GITHUB_OUTPUT"
+                      echo "No unreleased changes found"
+                      echo "Skipping the release process"
                   fi
 
-            - name: Bump version (pre-release)
-              if: steps.has_changes.outputs.has_changes == 'true' && steps.release_type.outputs.pre_release == 'true'
-              run: cog bump --auto --disable-bump-commit --pre
-
-            - name: Bump version (stable)
-              if: steps.has_changes.outputs.has_changes == 'true' && steps.release_type.outputs.pre_release == 'false'
-              run: cog bump --auto --disable-bump-commit
-
-            - name: Get new version
+            - name: Record release version
               if: steps.has_changes.outputs.has_changes == 'true'
               id: version
               run: |
-                  NEW_VERSION=$(node -p "require('./package.json').version")
-                  echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+                  NEW_VERSION="${{ steps.has_changes.outputs.expected }}"
 
-            - name: Commit changes
+                  echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+                  echo "New version: ${NEW_VERSION}"
+
+            - name: Prepare release files in isolated Cocogitto clone
               if: steps.has_changes.outputs.has_changes == 'true'
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ steps.version.outputs.version }}
+                  PRE_RELEASE: ${{ steps.release_type.outputs.pre_release }}
+                  RELEASE_BRANCH: ${{ steps.branch.outputs.branch }}
               run: |
-                  git config user.name "imamiland-bot[bot]"
-                  git config user.email "152510784+imamiland-bot@users.noreply.github.com"
-                  git add CHANGELOG.md package.json
-                  git commit -m "chore(release): ${{ steps.version.outputs.version }} [skip ci]"
+                  set -euo pipefail
 
-            - name: Create local tag
+                  BASE_SHA="$(git rev-parse HEAD)"
+                  TMP_DIR="$(mktemp -d)"
+                  TMP_REPO="$TMP_DIR/repo"
+                  VERSION_TAG="v${VERSION}"
+
+                  cleanup() {
+                      rm -rf "$TMP_DIR"
+                  }
+                  trap cleanup EXIT
+
+                  git clone --shared "$GITHUB_WORKSPACE" "$TMP_REPO"
+                  git -C "$TMP_REPO" checkout -B "$RELEASE_BRANCH" "$BASE_SHA"
+
+                  TMP_BRANCH="$(git -C "$TMP_REPO" branch --show-current)"
+                  if [ "$TMP_BRANCH" != "$RELEASE_BRANCH" ]; then
+                      echo "::error::Temporary Cocogitto clone is on '$TMP_BRANCH', expected '$RELEASE_BRANCH'."
+                      exit 1
+                  fi
+
+                  cd "$TMP_REPO"
+
+                  # Keep Cocogitto's tag side effects inside this disposable clone.
+                  # The real release commit is created later through GitHub's
+                  # createCommitOnBranch mutation using the GitHub App identity.
+                  if [ "$PRE_RELEASE" = "true" ]; then
+                      cog bump --auto --disable-bump-commit --pre --skip-untracked --hook-profile ci-release-prepare
+                  else
+                      cog bump --auto --disable-bump-commit --skip-untracked --hook-profile ci-release-prepare
+                  fi
+
+                  if cog changelog --at "$VERSION_TAG" > "$TMP_DIR/release_notes.md"; then
+                      echo "Generated release notes for $VERSION_TAG"
+                  else
+                      cog changelog --at "$VERSION" > "$TMP_DIR/release_notes.md"
+                      echo "Generated release notes for $VERSION"
+                  fi
+
+                  if [ ! -s "$TMP_DIR/release_notes.md" ]; then
+                      echo "::error::Cocogitto generated empty release notes."
+                      exit 1
+                  fi
+
+                  # With --disable-bump-commit, Cocogitto may not leave CHANGELOG.md
+                  # changed in the working tree. Generate the release notes explicitly
+                  # and prepend them to CHANGELOG.md so the later GraphQL commit has a
+                  # real, reviewable release-file change to publish.
+                  if [ -f CHANGELOG.md ] && { grep -Fq "$VERSION_TAG" CHANGELOG.md || grep -Fq "$VERSION" CHANGELOG.md; }; then
+                      echo "CHANGELOG.md already contains $VERSION_TAG / $VERSION; not prepending duplicate notes."
+                  elif [ -f CHANGELOG.md ] && head -n 1 CHANGELOG.md | grep -Eq '^# '; then
+                      {
+                          head -n 1 CHANGELOG.md
+                          echo
+                          cat "$TMP_DIR/release_notes.md"
+                          echo
+                          tail -n +2 CHANGELOG.md | sed '/./,$!d'
+                      } > "$TMP_DIR/CHANGELOG.md"
+                      mv "$TMP_DIR/CHANGELOG.md" CHANGELOG.md
+                  elif [ -f CHANGELOG.md ]; then
+                      {
+                          cat "$TMP_DIR/release_notes.md"
+                          echo
+                          cat CHANGELOG.md
+                      } > "$TMP_DIR/CHANGELOG.md"
+                      mv "$TMP_DIR/CHANGELOG.md" CHANGELOG.md
+                  else
+                      cp "$TMP_DIR/release_notes.md" CHANGELOG.md
+                  fi
+
+                  CHANGED_FILES="$(git diff --name-only)"
+
+                  if [ -z "$CHANGED_FILES" ]; then
+                      echo "::error::Cocogitto produced no release file changes."
+                      exit 1
+                  fi
+
+                  ALLOWED='^(CHANGELOG\.md|package\.json)$'
+                  BAD_FILES="$(echo "$CHANGED_FILES" | grep -Ev "$ALLOWED" || true)"
+
+                  if [ -n "$BAD_FILES" ]; then
+                      echo "::error::Release preparation changed files outside CHANGELOG.md and package.json:"
+                      echo "$BAD_FILES"
+                      exit 1
+                  fi
+
+                  DELETED_FILES="$(git diff --name-only --diff-filter=D)"
+                  if [ -n "$DELETED_FILES" ]; then
+                      echo "::error::Release preparation must not delete files:"
+                      echo "$DELETED_FILES"
+                      exit 1
+                  fi
+
+                  git diff --name-only -z --diff-filter=ACMRT -- CHANGELOG.md package.json > "$TMP_DIR/changed.z"
+
+                  if [ -s "$TMP_DIR/changed.z" ]; then
+                      tar --null -cf "$TMP_DIR/release-files.tar" --files-from "$TMP_DIR/changed.z"
+                      tar -xf "$TMP_DIR/release-files.tar" -C "$GITHUB_WORKSPACE"
+                  fi
+
+                  cp "$TMP_DIR/release_notes.md" /tmp/release_notes.md
+
+                  echo
+                  echo "Generated release notes:"
+                  echo
+                  cat /tmp/release_notes.md
+
+            - name: Validate release file changes
               if: steps.has_changes.outputs.has_changes == 'true'
               run: |
-                  TAG="v${{ steps.version.outputs.version }}"
-                  git tag -a "$TAG" -m "Release $TAG"
+                  set -euo pipefail
 
-            - name: Generate incremental release notes
-              if: steps.has_changes.outputs.has_changes == 'true'
+                  ALLOWED='^(CHANGELOG\.md|package\.json)$'
+
+                  CHANGED_FILES="$(git diff --name-only)"
+
+                  if [ -z "$CHANGED_FILES" ]; then
+                      echo "::error::No files changed after release preparation."
+                      exit 1
+                  fi
+
+                  BAD_FILES="$(echo "$CHANGED_FILES" | grep -Ev "$ALLOWED" || true)"
+
+                  if [ -n "$BAD_FILES" ]; then
+                      echo "::error::Release commit contains unexpected files:"
+                      echo "$BAD_FILES"
+                      exit 1
+                  fi
+
+                  echo "Release file changes are valid:"
+                  echo "$CHANGED_FILES"
+
+            - name: Show dry-run release changes
+              if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'true'
               run: |
-                  TAG="v${{ steps.version.outputs.version }}"
-                  cog changelog --at "$TAG" > /tmp/release_notes.md
+                  echo "Dry run enabled. Release commit, tags, and GitHub Release will not be created."
+                  echo
+                  echo "Target branch: ${{ steps.branch.outputs.branch }}"
+                  echo "Pre-release:   ${{ steps.release_type.outputs.pre_release }}"
+                  echo "Version:       ${{ steps.version.outputs.version }}"
+                  echo
+                  echo "Changed files:"
+                  git diff --name-only
+                  echo
+                  echo "Diff:"
+                  git diff -- CHANGELOG.md package.json || true
+                  echo
+                  echo "Release notes:"
+                  cat /tmp/release_notes.md
 
-            - name: Push commit and tag
-              if: steps.has_changes.outputs.has_changes == 'true'
+            - name: Verify exact release tag does not exist remotely
+              if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
               run: |
+                  set -euo pipefail
+
                   REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-                  TAG="v${{ steps.version.outputs.version }}"
-                  git push "$REMOTE" HEAD:${{ github.ref_name }}
-                  git push "$REMOTE" "$TAG"
+                  VERSION_TAG="v${{ steps.version.outputs.version }}"
+
+                  if git ls-remote --exit-code --tags "$REMOTE" "refs/tags/$VERSION_TAG" >/dev/null 2>&1; then
+                      echo "::error::Remote tag $VERSION_TAG already exists."
+                      exit 1
+                  fi
+
+                  echo "Remote tag $VERSION_TAG does not exist."
+
+            - name: Create verified release commit
+              if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
+              id: release_commit
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              env:
+                  BASE_REF: ${{ steps.branch.outputs.branch }}
+                  VERSION: ${{ steps.version.outputs.version }}
+              with:
+                  github-token: ${{ steps.app_token.outputs.token }}
+                  script: |
+                      const fs = require("fs");
+                      const { execSync } = require("child_process");
+
+                      const owner = context.repo.owner;
+                      const repo = context.repo.repo;
+                      const branchName = process.env.BASE_REF;
+                      const version = process.env.VERSION;
+
+                      const expectedHeadOid = execSync("git rev-parse HEAD", {
+                        encoding: "utf8",
+                      }).trim();
+
+                      const allowedPaths = new Set(["CHANGELOG.md", "package.json"]);
+
+                      const changedFiles = execSync("git diff --name-only", {
+                        encoding: "utf8",
+                      })
+                        .trim()
+                        .split("\n")
+                        .filter(Boolean);
+
+                      const unexpectedFiles = changedFiles.filter(
+                        (path) => !allowedPaths.has(path),
+                      );
+
+                      if (unexpectedFiles.length > 0) {
+                        core.setFailed(
+                          `Release commit may only change CHANGELOG.md and package.json.
+                           Unexpected files: ${unexpectedFiles.join(", ")}`,
+                        );
+                        return;
+                      }
+
+                      const deletedFiles = execSync(
+                        "git diff --name-only --diff-filter=D -- CHANGELOG.md package.json",
+                        { encoding: "utf8" },
+                      )
+                        .trim()
+                        .split("\n")
+                        .filter(Boolean);
+
+                      if (deletedFiles.length > 0) {
+                        core.setFailed(
+                          `Release commit must not delete files: ${deletedFiles.join(", ")}`,
+                        );
+                        return;
+                      }
+
+                      const additions = execSync(
+                        "git diff --name-only --diff-filter=ACMRT -- CHANGELOG.md package.json",
+                        { encoding: "utf8" },
+                      )
+                        .trim()
+                        .split("\n")
+                        .filter(Boolean)
+                        .map((path) => ({
+                          path,
+                          contents: fs.readFileSync(path).toString("base64"),
+                        }));
+
+                      if (additions.length === 0) {
+                        core.setFailed("No changed release files to commit.");
+                        return;
+                      }
+
+                      const mutation = `
+                        mutation CreateReleaseCommit($input: CreateCommitOnBranchInput!) {
+                          createCommitOnBranch(input: $input) {
+                            commit {
+                              oid
+                              url
+                            }
+                          }
+                        }
+                      `;
+
+                      const result = await github.graphql(mutation, {
+                        input: {
+                          branch: {
+                            repositoryNameWithOwner: `${owner}/${repo}`,
+                            branchName,
+                          },
+                          message: {
+                            headline: `chore(release): ${version} [skip ci]`,
+                          },
+                          fileChanges: {
+                            additions,
+                          },
+                          expectedHeadOid,
+                        },
+                      });
+
+                      const oid = result.createCommitOnBranch.commit.oid;
+                      const url = result.createCommitOnBranch.commit.url;
+
+                      core.info(`Created verified release commit: ${oid}`);
+                      core.info(url);
+
+                      core.setOutput("sha", oid);
+                      core.setOutput("url", url);
+
+            - name: Verify release commit was created
+              if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
+              env:
+                  GH_TOKEN: ${{ steps.app_token.outputs.token }}
+              run: |
+                  set -euo pipefail
+
+                  EXPECTED_SHA="${{ steps.release_commit.outputs.sha }}"
+
+                  if [ -z "$EXPECTED_SHA" ]; then
+                      echo "::error::Release commit SHA is empty. Commit creation may have failed."
+                      exit 1
+                  fi
+
+                  # Verify the commit exists on the remote via API.
+                  gh api repos/${{ github.repository }}/commits/"$EXPECTED_SHA" --jq '.sha' >/dev/null 2>&1 || {
+                      echo "::error::Could not verify release commit $EXPECTED_SHA on remote."
+                      exit 1
+                  }
+
+                  echo "Release commit $EXPECTED_SHA verified on remote."
+
+            - name: Refresh checkout to release commit
+              if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
+              env:
+                  GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+              run: |
+                  set -euo pipefail
+
+                  BASE_REF="${{ steps.branch.outputs.branch }}"
+
+                  git fetch origin "$BASE_REF"
+                  git reset --hard "origin/$BASE_REF"
+
+                  CURRENT_SHA="$(git rev-parse HEAD)"
+                  EXPECTED_SHA="${{ steps.release_commit.outputs.sha }}"
+
+                  if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
+                      echo "::error::Local checkout is not at the release commit."
+                      echo "Current:  $CURRENT_SHA"
+                      echo "Expected: $EXPECTED_SHA"
+                      exit 1
+                  fi
+
+                  echo "Checkout refreshed to release commit: $CURRENT_SHA"
+
+            - name: Create local semver tags
+              if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
+              id: tags
+              run: |
+                  set -euo pipefail
+
+                  VERSION_TAG="v${{ steps.version.outputs.version }}"
+
+                  SHOULD_MOVE_TAGS=false
+                  if [ "${{ steps.branch.outputs.branch }}" = "main" ] &&
+                  [ "${{ steps.release_type.outputs.pre_release }}" = "false" ]; then
+                      SHOULD_MOVE_TAGS=true
+                  fi
+
+                  MAJOR_TAG="$(echo "$VERSION_TAG" | sed -E 's/^(v[0-9]+)\..*/\1/')"
+                  MINOR_TAG="$(echo "$VERSION_TAG" | sed -E 's/^(v[0-9]+\.[0-9]+)\..*/\1/')"
+
+                  echo "version_tag=$VERSION_TAG" >> "$GITHUB_OUTPUT"
+                  echo "major_tag=$MAJOR_TAG" >> "$GITHUB_OUTPUT"
+                  echo "minor_tag=$MINOR_TAG" >> "$GITHUB_OUTPUT"
+                  echo "moving_tags=$SHOULD_MOVE_TAGS" >> "$GITHUB_OUTPUT"
+
+                  git tag "$VERSION_TAG"
+
+                  echo "Created local tags:"
+                  echo "$VERSION_TAG"
+
+                  if [ "$SHOULD_MOVE_TAGS" = "true" ]; then
+                      git tag -f "$MINOR_TAG"
+                      git tag -f "$MAJOR_TAG"
+
+                      echo "Created moving tags for stable main release:"
+                      echo "$MINOR_TAG"
+                      echo "$MAJOR_TAG"
+                  else
+                      echo "Skipping moving major/minor tags because this is not a stable main release."
+                      echo "Branch:      ${{ steps.branch.outputs.branch }}"
+                      echo "Pre-release: ${{ steps.release_type.outputs.pre_release }}"
+                  fi
+
+            - name: Push semver tags
+              if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
+              env:
+                  GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+              run: |
+                  set -euo pipefail
+
+                  REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+
+                  VERSION_TAG="${{ steps.tags.outputs.version_tag }}"
+                  MINOR_TAG="${{ steps.tags.outputs.minor_tag }}"
+                  MAJOR_TAG="${{ steps.tags.outputs.major_tag }}"
+                  MOVING_TAGS="${{ steps.tags.outputs.moving_tags }}"
+
+                  # Exact version tag is never force-pushed: if it already exists,
+                  # something is wrong and we want a loud failure.
+                  git push "$REMOTE" "$VERSION_TAG"
+
+                  if [ "$MOVING_TAGS" = "true" ]; then
+                      # Major/minor tags are intentionally moving tags, but only for
+                      # stable releases from main. Pre-releases from next must not move
+                      # vX or vX.Y.
+                      git push "$REMOTE" "$MINOR_TAG" --force
+                      git push "$REMOTE" "$MAJOR_TAG" --force
+                  else
+                      echo "Skipping moving major/minor tag push."
+                  fi
 
             - name: Create GitHub Release
-              if: steps.has_changes.outputs.has_changes == 'true'
-              uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
-              with:
-                  tag_name: 'v${{ steps.version.outputs.version }}'
-                  name: 'Release v${{ steps.version.outputs.version }}'
-                  body_path: /tmp/release_notes.md
-                  draft: false
-                  prerelease: ${{ steps.release_type.outputs.pre_release == 'true' }}
+              if: steps.has_changes.outputs.has_changes == 'true' && steps.mode.outputs.dry_run == 'false'
+              env:
+                  GH_TOKEN: ${{ steps.app_token.outputs.token }}
+              run: |
+                  set -euo pipefail
+
+                  TAG="v${{ steps.version.outputs.version }}"
+
+                  if [ "${{ steps.release_type.outputs.pre_release }}" = "true" ]; then
+                      PRERELEASE_FLAG="--prerelease"
+                  else
+                      PRERELEASE_FLAG=""
+                  fi
+
+                  gh release create "$TAG" \
+                      --title "Release $TAG" \
+                      --notes-file /tmp/release_notes.md \
+                      $PRERELEASE_FLAG

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -52,6 +52,6 @@ jobs:
                   retention-days: 5
 
             - name: Upload to code-scanning
-              uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+              uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
               with:
                   sarif_file: results.sarif

--- a/cog.toml
+++ b/cog.toml
@@ -31,3 +31,7 @@ path = "CHANGELOG.md"
 authors = []
 
 [bump_profiles]
+
+[bump_profiles.ci-release-prepare]
+pre_bump_hooks = ["npm pkg set version={{version}}"]
+post_bump_hooks = []


### PR DESCRIPTION
# Description

This pull request introduces a couple of minor but important updates related to CI/CD workflows and release automation. The main changes include updating the GitHub Action used for SARIF uploads and configuring a new bump profile for release preparation.

CI/CD workflow updates:

* Updated the `github/codeql-action/upload-sarif` action in `.github/workflows/scorecard.yaml` to a newer commit hash, ensuring the latest fixes and features are used.

Release automation improvements:

* Added a new `ci-release-prepare` bump profile to `cog.toml`, which sets up a pre-bump hook to update the npm package version automatically before release.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
